### PR TITLE
Allows null for encounter class because Epic didn't conform to the FHIR specification

### DIFF
--- a/cumulus_library_kidney_transplant/athena/irae__cohort_study_population.sql
+++ b/cumulus_library_kidney_transplant/athena/irae__cohort_study_population.sql
@@ -54,8 +54,8 @@ StudyPopulation as
     where
         (E.encounter_ref = SP.encounter_ref)  and
         (E.gender = G.code)                   and
-        (E.age_at_visit between age.age_min and age.age_max) and
-        (E.class_code is null OR E.class_code = enc_class.code)     -- https://github.com/smart-on-fhir/cumulus-library-kidney-transplant/issues/28
+        (E.age_at_visit between age.age_min and age.age_max)
+        -- https://github.com/smart-on-fhir/cumulus-library-kidney-transplant/issues/28
 ),
 Utilization as
 (

--- a/cumulus_library_kidney_transplant/template/cohort_study_population.sql
+++ b/cumulus_library_kidney_transplant/template/cohort_study_population.sql
@@ -54,8 +54,8 @@ StudyPopulation as
     where
         (E.encounter_ref = SP.encounter_ref)  and
         (E.gender = G.code)                   and
-        (E.age_at_visit between age.age_min and age.age_max) and
-        (E.class_code is null OR E.class_code = enc_class.code)     -- https://github.com/smart-on-fhir/cumulus-library-kidney-transplant/issues/28
+        (E.age_at_visit between age.age_min and age.age_max)
+        -- https://github.com/smart-on-fhir/cumulus-library-kidney-transplant/issues/28
 ),
 Utilization as
 (


### PR DESCRIPTION
IF Null, "allow any" Encounter class. Epic dropped the ball and did not conform to the FHIR standard. 

If NOT null for systems like Cerner that do conform to the standard, perform the checks to ensure the Encounter class is the is in the desired list. 

Change is made to the SQL template and generated Athena SQL.