### PR TITLE
ETL support added "group_name" from etl__completion_encounters.

### DIFF
--- a/cumulus_library_kidney_transplant/athena/irae__sample_casedef_index.sql
+++ b/cumulus_library_kidney_transplant/athena/irae__sample_casedef_index.sql
@@ -7,12 +7,15 @@ SELECT  distinct
         doc.doc_type_display,
         doc.doc_type_system,
         doc.doc_author_day,
-        doc.enc_period_start_day
-FROM    irae__cohort_casedef_include as include,
+        doc.enc_period_start_day,
+        etl.group_name
+FROM    etl__completion_encounters      as etl,
+        irae__cohort_casedef_include as include,
         irae__cohort_casedef_index as casedef,
         irae__cohort_study_population_doc as doc
 WHERE   casedef.subject_ref = include.subject_ref
 AND     casedef.encounter_ref = doc.encounter_ref
+AND     casedef.encounter_ref = concat('Encounter/', etl.encounter_id)
 ORDER BY
     subject_ref,
     enc_period_start_day,

--- a/cumulus_library_kidney_transplant/athena/irae__sample_casedef_post.sql
+++ b/cumulus_library_kidney_transplant/athena/irae__sample_casedef_post.sql
@@ -7,12 +7,15 @@ SELECT  distinct
         doc.doc_type_display,
         doc.doc_type_system,
         doc.doc_author_day,
-        doc.enc_period_start_day
-FROM    irae__cohort_casedef_include as include,
+        doc.enc_period_start_day,
+        etl.group_name
+FROM    etl__completion_encounters      as etl,
+        irae__cohort_casedef_include as include,
         irae__cohort_casedef_post as casedef,
         irae__cohort_study_population_doc as doc
 WHERE   casedef.subject_ref = include.subject_ref
 AND     casedef.encounter_ref = doc.encounter_ref
+AND     casedef.encounter_ref = concat('Encounter/', etl.encounter_id)
 ORDER BY
     subject_ref,
     enc_period_start_day,

--- a/cumulus_library_kidney_transplant/athena/irae__sample_casedef_pre.sql
+++ b/cumulus_library_kidney_transplant/athena/irae__sample_casedef_pre.sql
@@ -7,12 +7,15 @@ SELECT  distinct
         doc.doc_type_display,
         doc.doc_type_system,
         doc.doc_author_day,
-        doc.enc_period_start_day
-FROM    irae__cohort_casedef_include as include,
+        doc.enc_period_start_day,
+        etl.group_name
+FROM    etl__completion_encounters      as etl,
+        irae__cohort_casedef_include as include,
         irae__cohort_casedef_pre as casedef,
         irae__cohort_study_population_doc as doc
 WHERE   casedef.subject_ref = include.subject_ref
 AND     casedef.encounter_ref = doc.encounter_ref
+AND     casedef.encounter_ref = concat('Encounter/', etl.encounter_id)
 ORDER BY
     subject_ref,
     enc_period_start_day,

--- a/cumulus_library_kidney_transplant/template/sample_casedef.sql
+++ b/cumulus_library_kidney_transplant/template/sample_casedef.sql
@@ -7,12 +7,15 @@ SELECT  distinct
         doc.doc_type_display,
         doc.doc_type_system,
         doc.doc_author_day,
-        doc.enc_period_start_day
-FROM    $prefix__cohort_casedef_include as include,
+        doc.enc_period_start_day,
+        etl.group_name
+FROM    etl__completion_encounters      as etl,
+        $prefix__cohort_casedef_include as include,
         $prefix__cohort_casedef_$suffix as casedef,
         $prefix__cohort_study_population_doc as doc
 WHERE   casedef.subject_ref = include.subject_ref
 AND     casedef.encounter_ref = doc.encounter_ref
+AND     casedef.encounter_ref = concat('Encounter/', etl.encounter_id)
 ORDER BY
     subject_ref,
     enc_period_start_day,


### PR DESCRIPTION
ETL support added "group_name" from etl__completion_encounters to sample tables for pre/index/post case definition. 

FYI: this mini PR does not include other metadata enrichment for sampling, just the ETL support. 