### PR TITLE
hotfix: caught an issue with the sql jinja generating a broken query for deceased_datetime

### DIFF
--- a/cumulus_library_kidney_transplant/nlp_result_to_highlights/irae__highlights.sql.jinja
+++ b/cumulus_library_kidney_transplant/nlp_result_to_highlights/irae__highlights.sql.jinja
@@ -173,8 +173,8 @@ CREATE TABLE irae__highlights AS
         {{ table_name }} AS src,
         UNNEST(src.result.deceased_mention.spans) AS t4(span)
     WHERE 
-        src.result.{{mention_key}}.deceased IS NOT NULL
-        AND src.result.{{mention_key}}.deceased 
+        src.result.deceased_mention.deceased IS NOT NULL
+        AND src.result.deceased_mention.deceased 
 {{ union_all_delineate(loop) }}
 {%- endfor %}
 {%- else %}


### PR DESCRIPTION
Tested on E3 with this latest version of the jinja template and was able to create the highlight table (irae__highlights) appropriately! 