### PR TITLE
NLP: Enum names now aligned with values

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+### Checklist
+- [ ] Consider if documentation needs to be updated
+- [ ] Consider if tests should be added
+- [ ] If your PR updates Pydantic, make sure you've done the following before finalizing your updates
+  - [ ] For schemas that have changed, update impacted task versions in **SQL template files**
+  - [ ] For schemas that have changed, update impacted task versions in **cumulus_library_kidney_transplant/nlp_clinical_tasks.toml** 
+  - [ ] `python cumulus_library_kidney_transplant/llm/create_model_summary.py`
+  - [ ] `python cumulus_library_kidney_transplant/llm/create_schema.py`
+  - [ ] `python cumulus_library_kidney_transplant/llm/create_wide_sql_examples.py`

--- a/cumulus_library_kidney_transplant/llm/athena/irae__llm_donor_highlights.sql
+++ b/cumulus_library_kidney_transplant/llm/athena/irae__llm_donor_highlights.sql
@@ -15,8 +15,8 @@ CREATE TABLE irae__llm_donor_highlights AS
         irae__nlp_donor_gpt_oss_120b AS src, 
         UNNEST(src.result.donor_transplant_date_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
-        src.task_version = CAST('7' AS INT)
+    WHERE
+        src.task_version = 8
         AND src.result.donor_transplant_date_mention IS NOT NULL
         AND src.result.donor_transplant_date_mention.donor_transplant_date IS NOT NULL
     UNION ALL
@@ -36,10 +36,10 @@ CREATE TABLE irae__llm_donor_highlights AS
         irae__nlp_donor_gpt_oss_120b AS src, 
         UNNEST(src.result.donor_type_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
-        src.task_version = CAST('7' AS INT)
+    WHERE
+        src.task_version = 8
         AND src.result.donor_type_mention IS NOT NULL
-        AND src.result.donor_type_mention.donor_type != 'Donor was not mentioned as living or deceased'
+        AND src.result.donor_type_mention.donor_type != 'NOT_MENTIONED'
     UNION ALL
     SELECT
         src.note_ref,
@@ -57,10 +57,10 @@ CREATE TABLE irae__llm_donor_highlights AS
         irae__nlp_donor_gpt_oss_120b AS src, 
         UNNEST(src.result.donor_relationship_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
-        src.task_version = CAST('7' AS INT)
+    WHERE
+        src.task_version = 8
         AND src.result.donor_relationship_mention IS NOT NULL
-        AND src.result.donor_relationship_mention.donor_relationship != 'Donor relationship status was not mentioned'
+        AND src.result.donor_relationship_mention.donor_relationship != 'NOT_MENTIONED'
     UNION ALL
     SELECT
         src.note_ref,
@@ -78,10 +78,10 @@ CREATE TABLE irae__llm_donor_highlights AS
         irae__nlp_donor_gpt_oss_120b AS src, 
         UNNEST(src.result.donor_hla_match_quality_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
-        src.task_version = CAST('7' AS INT)
+    WHERE
+        src.task_version = 8
         AND src.result.donor_hla_match_quality_mention IS NOT NULL
-        AND src.result.donor_hla_match_quality_mention.donor_hla_match_quality != 'HLA match quality not mentioned'
+        AND src.result.donor_hla_match_quality_mention.donor_hla_match_quality != 'NOT_MENTIONED'
     UNION ALL
     SELECT
         src.note_ref,
@@ -99,10 +99,10 @@ CREATE TABLE irae__llm_donor_highlights AS
         irae__nlp_donor_gpt_oss_120b AS src, 
         UNNEST(src.result.donor_hla_mismatch_count_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
-        src.task_version = CAST('7' AS INT)
+    WHERE
+        src.task_version = 8
         AND src.result.donor_hla_mismatch_count_mention IS NOT NULL
-        AND src.result.donor_hla_mismatch_count_mention.donor_hla_mismatch_count != 'HLA mismatch count not mentioned'
+        AND src.result.donor_hla_mismatch_count_mention.donor_hla_mismatch_count != 'NOT_MENTIONED'
     UNION ALL
     SELECT
         src.note_ref,
@@ -120,8 +120,8 @@ CREATE TABLE irae__llm_donor_highlights AS
         irae__nlp_donor_gpt_oss_120b AS src, 
         UNNEST(src.result.donor_serostatus_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
-        src.task_version = CAST('7' AS INT)
+    WHERE
+        src.task_version = 8
         AND src.result.donor_serostatus_mention IS NOT NULL
         AND src.result.donor_serostatus_mention.serostatus != 'NOT_MENTIONED'
     UNION ALL
@@ -141,8 +141,8 @@ CREATE TABLE irae__llm_donor_highlights AS
         irae__nlp_donor_gpt_oss_120b AS src, 
         UNNEST(src.result.donor_serostatus_cmv_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
-        src.task_version = CAST('7' AS INT)
+    WHERE
+        src.task_version = 8
         AND src.result.donor_serostatus_cmv_mention IS NOT NULL
         AND src.result.donor_serostatus_cmv_mention.serostatus != 'NOT_MENTIONED'
     UNION ALL
@@ -162,8 +162,8 @@ CREATE TABLE irae__llm_donor_highlights AS
         irae__nlp_donor_gpt_oss_120b AS src, 
         UNNEST(src.result.donor_serostatus_ebv_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
-        src.task_version = CAST('7' AS INT)
+    WHERE
+        src.task_version = 8
         AND src.result.donor_serostatus_ebv_mention IS NOT NULL
         AND src.result.donor_serostatus_ebv_mention.serostatus != 'NOT_MENTIONED'
     UNION ALL
@@ -183,8 +183,8 @@ CREATE TABLE irae__llm_donor_highlights AS
         irae__nlp_donor_gpt_oss_120b AS src, 
         UNNEST(src.result.recipient_serostatus_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
-        src.task_version = CAST('7' AS INT)
+    WHERE
+        src.task_version = 8
         AND src.result.recipient_serostatus_mention IS NOT NULL
         AND src.result.recipient_serostatus_mention.serostatus != 'NOT_MENTIONED'
     UNION ALL
@@ -204,8 +204,8 @@ CREATE TABLE irae__llm_donor_highlights AS
         irae__nlp_donor_gpt_oss_120b AS src, 
         UNNEST(src.result.recipient_serostatus_cmv_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
-        src.task_version = CAST('7' AS INT)
+    WHERE
+        src.task_version = 8
         AND src.result.recipient_serostatus_cmv_mention IS NOT NULL
         AND src.result.recipient_serostatus_cmv_mention.serostatus != 'NOT_MENTIONED'
     UNION ALL
@@ -225,8 +225,8 @@ CREATE TABLE irae__llm_donor_highlights AS
         irae__nlp_donor_gpt_oss_120b AS src, 
         UNNEST(src.result.recipient_serostatus_ebv_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
-        src.task_version = CAST('7' AS INT)
+    WHERE
+        src.task_version = 8
         AND src.result.recipient_serostatus_ebv_mention IS NOT NULL
         AND src.result.recipient_serostatus_ebv_mention.serostatus != 'NOT_MENTIONED'
     

--- a/cumulus_library_kidney_transplant/llm/athena/irae__llm_donor_wide.sql
+++ b/cumulus_library_kidney_transplant/llm/athena/irae__llm_donor_wide.sql
@@ -20,4 +20,4 @@ SELECT DISTINCT
 FROM
     irae__nlp_donor_gpt_oss_120b AS nlp
 WHERE
-    task_version = 7
+    task_version = 8

--- a/cumulus_library_kidney_transplant/llm/athena/irae__llm_immunosuppressive_medications_highlights.sql
+++ b/cumulus_library_kidney_transplant/llm/athena/irae__llm_immunosuppressive_medications_highlights.sql
@@ -20,9 +20,9 @@ FROM
             CAST(ARRAY[ARRAY[]] AS ARRAY(ARRAY(INTEGER)))
         )
     ) AS t2(span)
-WHERE 
-    src.task_version = CAST('6' AS INT)
-    AND medication.status <> 'None of the above'
+WHERE
+    src.task_version = 7
+    AND medication.status <> 'NONE_OF_THE_ABOVE'
 -- Second pass to get medication ingredient information --
 UNION ALL
 SELECT
@@ -36,15 +36,15 @@ SELECT
     CONCAT(CAST(span[1] AS VARCHAR), ':', CAST(span[2] AS VARCHAR)) AS span,
     'Medication' AS sublabel_name,
     medication.ingredient AS sublabel_value
-FROM 
+FROM
     irae__nlp_immunosuppressive_medications_gpt_oss_120b AS src,
     UNNEST(src.result.immunosuppressive_medication_mentions) AS t1(medication),
     UNNEST(
         COALESCE(
-            medication.spans, 
+            medication.spans,
             CAST(ARRAY[ARRAY[]] AS ARRAY(ARRAY(INTEGER)))
         )
     ) AS t2(span)
-WHERE 
-    src.task_version = CAST('6' AS INT)
-    AND medication.ingredient <> 'None of the above'
+WHERE
+    src.task_version = 7
+    AND medication.ingredient <> 'NONE_OF_THE_ABOVE'

--- a/cumulus_library_kidney_transplant/llm/athena/irae__llm_immunosuppressive_medications_wide.sql
+++ b/cumulus_library_kidney_transplant/llm/athena/irae__llm_immunosuppressive_medications_wide.sql
@@ -27,5 +27,5 @@ FROM
     irae__nlp_immunosuppressive_medications_gpt_oss_120b AS nlp,
     UNNEST(nlp.result.immunosuppressive_medication_mentions) AS t(medication)
 WHERE
-    task_version = 6
-    AND medication.drug_class <> 'None of the above'
+    task_version = 7
+    AND medication.drug_class <> 'NONE_OF_THE_ABOVE'

--- a/cumulus_library_kidney_transplant/llm/athena/irae__llm_longitudinal_highlights.sql
+++ b/cumulus_library_kidney_transplant/llm/athena/irae__llm_longitudinal_highlights.sql
@@ -16,7 +16,7 @@ CREATE TABLE irae__llm_longitudinal_highlights AS
         UNNEST(src.result.rx_therapeutic_status_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
     WHERE
-        src.result.rx_therapeutic_status_mention.rx_therapeutic_status != 'None of the above'
+        src.result.rx_therapeutic_status_mention.rx_therapeutic_status != 'NONE_OF_THE_ABOVE'
 
     UNION ALL
     SELECT
@@ -36,7 +36,7 @@ CREATE TABLE irae__llm_longitudinal_highlights AS
         UNNEST(src.result.rx_compliance_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
     WHERE
-        src.result.rx_compliance_mention.rx_compliance != 'None of the above'
+        src.result.rx_compliance_mention.rx_compliance != 'NONE_OF_THE_ABOVE'
 
     UNION ALL
     SELECT
@@ -55,9 +55,9 @@ CREATE TABLE irae__llm_longitudinal_highlights AS
         irae__nlp_longitudinal_gpt_oss_120b AS src, 
         UNNEST(src.result.dsa_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
+    WHERE
         src.result.dsa_mention.dsa_history
-        AND src.result.dsa_mention.dsa != 'None of the above'
+        AND src.result.dsa_mention.dsa != 'NONE_OF_THE_ABOVE'
 
     UNION ALL
     SELECT
@@ -76,9 +76,9 @@ CREATE TABLE irae__llm_longitudinal_highlights AS
         irae__nlp_longitudinal_gpt_oss_120b AS src, 
         UNNEST(src.result.infection_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
+    WHERE
         src.result.infection_mention.infection_history
-        AND src.result.infection_mention.infection != 'None of the above'
+        AND src.result.infection_mention.infection != 'NONE_OF_THE_ABOVE'
 
     UNION ALL
     SELECT
@@ -97,9 +97,9 @@ CREATE TABLE irae__llm_longitudinal_highlights AS
         irae__nlp_longitudinal_gpt_oss_120b AS src, 
         UNNEST(src.result.viral_infection_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
+    WHERE
         src.result.viral_infection_mention.viral_infection_history
-        AND src.result.viral_infection_mention.viral_infection != 'None of the above'
+        AND src.result.viral_infection_mention.viral_infection != 'NONE_OF_THE_ABOVE'
 
     UNION ALL
     SELECT
@@ -118,9 +118,9 @@ CREATE TABLE irae__llm_longitudinal_highlights AS
         irae__nlp_longitudinal_gpt_oss_120b AS src, 
         UNNEST(src.result.bacterial_infection_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
+    WHERE
         src.result.bacterial_infection_mention.bacterial_infection_history
-        AND src.result.bacterial_infection_mention.bacterial_infection != 'None of the above'
+        AND src.result.bacterial_infection_mention.bacterial_infection != 'NONE_OF_THE_ABOVE'
 
     UNION ALL
     SELECT
@@ -139,9 +139,9 @@ CREATE TABLE irae__llm_longitudinal_highlights AS
         irae__nlp_longitudinal_gpt_oss_120b AS src, 
         UNNEST(src.result.fungal_infection_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
+    WHERE
         src.result.fungal_infection_mention.fungal_infection_history
-        AND src.result.fungal_infection_mention.fungal_infection != 'None of the above'
+        AND src.result.fungal_infection_mention.fungal_infection != 'NONE_OF_THE_ABOVE'
 
     UNION ALL
     SELECT
@@ -160,9 +160,9 @@ CREATE TABLE irae__llm_longitudinal_highlights AS
         irae__nlp_longitudinal_gpt_oss_120b AS src, 
         UNNEST(src.result.graft_rejection_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
+    WHERE
         src.result.graft_rejection_mention.graft_rejection_history
-        AND src.result.graft_rejection_mention.graft_rejection != 'None of the above'
+        AND src.result.graft_rejection_mention.graft_rejection != 'NONE_OF_THE_ABOVE'
 
     UNION ALL
     SELECT
@@ -181,9 +181,9 @@ CREATE TABLE irae__llm_longitudinal_highlights AS
         irae__nlp_longitudinal_gpt_oss_120b AS src, 
         UNNEST(src.result.graft_failure_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
+    WHERE
         src.result.graft_failure_mention.graft_failure_history
-        AND src.result.graft_failure_mention.graft_failure != 'None of the above'
+        AND src.result.graft_failure_mention.graft_failure != 'NONE_OF_THE_ABOVE'
 
     UNION ALL
     SELECT
@@ -202,9 +202,9 @@ CREATE TABLE irae__llm_longitudinal_highlights AS
         irae__nlp_longitudinal_gpt_oss_120b AS src, 
         UNNEST(src.result.ptld_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
+    WHERE
         src.result.ptld_mention.ptld_history
-        AND src.result.ptld_mention.ptld != 'None of the above'
+        AND src.result.ptld_mention.ptld != 'NONE_OF_THE_ABOVE'
 
     UNION ALL
     SELECT
@@ -223,9 +223,9 @@ CREATE TABLE irae__llm_longitudinal_highlights AS
         irae__nlp_longitudinal_gpt_oss_120b AS src, 
         UNNEST(src.result.cancer_mention.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
+    WHERE
         src.result.cancer_mention.cancer_history
-        AND src.result.cancer_mention.cancer != 'None of the above'
+        AND src.result.cancer_mention.cancer != 'NONE_OF_THE_ABOVE'
 
     UNION ALL
     SELECT

--- a/cumulus_library_kidney_transplant/llm/athena/irae__llm_longitudinal_wide.sql
+++ b/cumulus_library_kidney_transplant/llm/athena/irae__llm_longitudinal_wide.sql
@@ -41,4 +41,4 @@ SELECT DISTINCT
 FROM
     irae__nlp_longitudinal_gpt_oss_120b AS nlp
 WHERE
-    task_version = 6
+    task_version = 7

--- a/cumulus_library_kidney_transplant/llm/model/base.py
+++ b/cumulus_library_kidney_transplant/llm/model/base.py
@@ -20,20 +20,37 @@ class SpanAugmentedMention(BaseModel):
 
 
 class RxFrequency(StrEnum):
-    QD = "QD"  # 1X (once daily)
-    BID = "BID"  # 2X (twice daily)
-    TID = "TID"  # 3X (three times daily)
-    QID = "QID"  # 4X (four times daily)
-    QOD = "QOD"  # 1/2X (every other day)
-    Q6H = "Q6H"  # 4X (every 6 hours)
-    Q8H = "Q8H"  # 3X (every 8 hours)
-    Q12H = "Q12H"  # 2X (every 12 hours)
-    WEEKLY = "WEEKLY"  # 1/7X (once every 7 days)
-    Q2W = "Q2W"  # 1/14X (once every 2 weeks = 14 days)
-    Q4W = "Q4W"  # 1/28X (once every 4 weeks = 28 days)
-    MONTHLY = "MONTHLY"  # 1/28X (once every 4 weeks = 28 days)
-    OTHER = "OTHER"  # use timing_text
-    NONE = "None of the above"
+    """
+    QD: once daily (1x/day)
+    BID: twice daily (2x/day)
+    TID: three times daily (3x/day)
+    QID: four times daily (4x/day)
+    QOD: every other day (1/2x/day)
+    Q6H: every 6 hours (4x/day)
+    Q8H: every 8 hours (3x/day)
+    Q12H: every 12 hours (2x/day)
+    WEEKLY: once every 7 days
+    Q2W: once every 2 weeks (14 days)
+    Q4W: once every 4 weeks (28 days)
+    MONTHLY: once every 4 weeks (28 days)
+    OTHER: use timing_text for non-standard frequency
+    NONE_OF_THE_ABOVE: None of the above
+    """
+
+    QD = "QD"
+    BID = "BID"
+    TID = "TID"
+    QID = "QID"
+    QOD = "QOD"
+    Q6H = "Q6H"
+    Q8H = "Q8H"
+    Q12H = "Q12H"
+    WEEKLY = "WEEKLY"
+    Q2W = "Q2W"
+    Q4W = "Q4W"
+    MONTHLY = "MONTHLY"
+    OTHER = "OTHER"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 ###############################################################################
@@ -45,15 +62,23 @@ class RxStatus(StrEnum):
     Medication Status (including Intent because chart review is NOT always identical to Med Request)
     https://build.fhir.org/valueset-medicationrequest-status.html
     https://build.fhir.org/valueset-medicationrequest-intent.html
+
+    ACTIVE: Medication order is active (currently prescribed and intended for ongoing use).
+    INTENDED: Medication is planned/ordered/prescribed but therapy has not yet started.
+    COMPLETED: Medication course is finished (all doses given or intended duration completed).
+    STOPPED: Medication was stopped or permanently discontinued before completion.
+    CANCELED: Medication order was canceled/withdrawn before any doses were administered.
+    ON_HOLD: Medication is temporarily paused (on-hold, suspended, or interrupted).
+    NONE_OF_THE_ABOVE: None of the above
     """
 
-    ACTIVE = "Medication order is active (currently prescribed and intended for ongoing use)."
-    INTENDED = "Medication is planned/ordered/prescribed but therapy has not yet started."
-    COMPLETED = "Medication course is finished (all doses given or intended duration completed)."
-    STOPPED = "Medication was stopped or permanently discontinued before completion."
-    CANCELED = "Medication order was canceled/withdrawn before any doses were administered."
-    ON_HOLD = "Medication is temporarily paused (on-hold, suspended, or interrupted)."
-    NONE = "None of the above"
+    ACTIVE = "ACTIVE"
+    INTENDED = "INTENDED"
+    COMPLETED = "COMPLETED"
+    STOPPED = "STOPPED"
+    CANCELED = "CANCELED"
+    ON_HOLD = "ON_HOLD"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 ###############################################################################
@@ -63,12 +88,17 @@ class RxStatus(StrEnum):
 class RxCategory(StrEnum):
     """
     https://build.fhir.org/valueset-medicationrequest-admin-location.html
+
+    INPATIENT: Medication ordered/administered during an inpatient/acute care setting
+    OUTPATIENT: Medication ordered/administered during an outpatient setting
+    COMMUNITY: Medication ordered/consumed by the patient in their home (including long term care, nursing homes, etc)
+    NONE_OF_THE_ABOVE: None of the above
     """
 
-    INPATIENT = "Medication ordered/administered during an inpatient/acute care setting"
-    OUTPATIENT = "Medication ordered/administered during an outpatient setting"
-    COMMUNITY = "Medication ordered/consumed by the patient in their home (including long term care, nursing homes, etc)"
-    NONE = "None of the above"
+    INPATIENT = "INPATIENT"
+    OUTPATIENT = "OUTPATIENT"
+    COMMUNITY = "COMMUNITY"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 ###############################################################################
@@ -82,14 +112,21 @@ class RxRoute(StrEnum):
     * Topical --> skin lesions
     * Inhalation --> Steroid
     https://build.fhir.org/valueset-route-codes.html
+
+    PO: Oral (includes swallowed and sublingual routes)
+    NG: Nasogastric/Feeding tube (NG/PEG)
+    INJECTION: Injection (IV, SC, or IM)
+    INHALATION: Inhalation (respiratory route)
+    TOPICAL: Topical (skin or mucosal surface)
+    NONE_OF_THE_ABOVE: None of the above
     """
 
-    PO = "Oral (includes swallowed and sublingual routes)"
-    NG = "Nasogastric/Feeding tube (NG/PEG)"
-    INJECTION = "Injection (IV, SC, or IM)"
-    INHALATION = "Inhalation (respiratory route)"
-    TOPICAL = "Topical (skin or mucosal surface)"
-    NONE = "None of the above"
+    PO = "PO"
+    NG = "NG"
+    INJECTION = "INJECTION"
+    INHALATION = "INHALATION"
+    TOPICAL = "TOPICAL"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 ###############################################################################
@@ -125,38 +162,50 @@ class RxValidityPeriodMention(SpanAugmentedMention):
 
 
 class RxQuantityUnit(StrEnum):
+    """
+    UCUM unit codes for medication quantity.
+
+    Mass: MG=mg, G=g, UG=ug (microgram/mcg), KG=kg
+    Volume: ML=mL, L=L
+    International Units: U=U, IU=[iU]
+    Countable: TABLET={tablet}, CAPSULE={capsule}, PUFF={puff}, PATCH={patch}, SUPPOSITORY={suppository}
+    Ratios: MG_PER_ML=mg/mL, MG_PER_KG=mg/kg, U_PER_KG=U/kg, UG_PER_KG_PER_MIN=ug/kg/min
+    Time (infusion rates): H=h, MIN=min, D=d
+    NONE_OF_THE_ABOVE: None of the above
+    """
+
     # Mass
-    MG = "mg"
-    G = "g"
-    UG = "ug"  # microgram (mcg)
-    KG = "kg"
+    MG = "MG"
+    G = "G"
+    UG = "UG"
+    KG = "KG"
 
     # Volume
-    ML = "mL"
+    ML = "ML"
     L = "L"
 
     # International Units
     U = "U"
-    IU = "[iU]"
+    IU = "IU"
 
     # Countable units
-    TABLET = "{tablet}"
-    CAPSULE = "{capsule}"
-    PUFF = "{puff}"
-    PATCH = "{patch}"
-    SUPPOSITORY = "{suppository}"
+    TABLET = "TABLET"
+    CAPSULE = "CAPSULE"
+    PUFF = "PUFF"
+    PATCH = "PATCH"
+    SUPPOSITORY = "SUPPOSITORY"
 
     # Ratios
-    MG_PER_ML = "mg/mL"
-    MG_PER_KG = "mg/kg"
-    U_PER_KG = "U/kg"
-    UG_PER_KG_PER_MIN = "ug/kg/min"
+    MG_PER_ML = "MG_PER_ML"
+    MG_PER_KG = "MG_PER_KG"
+    U_PER_KG = "U_PER_KG"
+    UG_PER_KG_PER_MIN = "UG_PER_KG_PER_MIN"
 
     # Time units (for infusion rates)
-    H = "h"
-    MIN = "min"
-    D = "d"
-    NONE = "None of the above"
+    H = "H"
+    MIN = "MIN"
+    D = "D"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 # MedicationRequest.dispenseRequest.quantity
@@ -166,8 +215,17 @@ class RxQuantity(SpanAugmentedMention):
     """
 
     unit: RxQuantityUnit = Field(
-        default=RxQuantityUnit.NONE,
-        description="Medication prescribed unit (examples: 'mg', 'ug/kg/min', 'tablet', etc)",
+        default=RxQuantityUnit.NONE_OF_THE_ABOVE,
+        description=(
+            "Medication prescribed unit. "
+            "Mass: MG=mg, G=g, UG=ug (microgram), KG=kg; "
+            "Volume: ML=mL, L=L; "
+            "International Units: U=U, IU=[iU]; "
+            "Countable: TABLET, CAPSULE, PUFF, PATCH, SUPPOSITORY; "
+            "Ratios: MG_PER_ML, MG_PER_KG, U_PER_KG, UG_PER_KG_PER_MIN; "
+            "Time: H=hours, MIN=minutes, D=days; "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
     value: str | None = Field(
@@ -183,12 +241,17 @@ class RxQuantity(SpanAugmentedMention):
 class TreatmentPhase(StrEnum):
     """
     Treatment Phase
+
+    INDUCTION: Induction therapy
+    MAINTENANCE: Maintenance therapy
+    RESCUE: Rescue therapy
+    NONE_OF_THE_ABOVE: None of the above
     """
 
-    INDUCTION = "Induction therapy"
-    MAINTENANCE = "Maintenance therapy"
-    RESCUE = "Rescue therapy"
-    NONE = "None of the above"
+    INDUCTION = "INDUCTION"
+    MAINTENANCE = "MAINTENANCE"
+    RESCUE = "RESCUE"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 ###############################################################################
@@ -206,21 +269,52 @@ class MedicationMention(SpanAugmentedMention):
     """
 
     status: RxStatus = Field(
-        default=RxStatus.NONE, description="What is the status of this medication?"
+        default=RxStatus.NONE_OF_THE_ABOVE,
+        description=(
+            "What is the status of this medication? "
+            "ACTIVE: Medication order is active (currently prescribed and intended for ongoing use); "
+            "INTENDED: Medication is planned/ordered/prescribed but therapy has not yet started; "
+            "COMPLETED: Medication course is finished (all doses given or intended duration completed); "
+            "STOPPED: Medication was stopped or permanently discontinued before completion; "
+            "CANCELED: Medication order was canceled/withdrawn before any doses were administered; "
+            "ON_HOLD: Medication is temporarily paused (on-hold, suspended, or interrupted); "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
     category: RxCategory = Field(
-        default=RxCategory.NONE,
-        description="In which healthcare setting is this medication prescribed/administered?",
+        default=RxCategory.NONE_OF_THE_ABOVE,
+        description=(
+            "In which healthcare setting is this medication prescribed/administered? "
+            "INPATIENT: Medication ordered/administered during an inpatient/acute care setting; "
+            "OUTPATIENT: Medication ordered/administered during an outpatient setting; "
+            "COMMUNITY: Medication ordered/consumed by the patient in their home (including long term care, nursing homes, etc); "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
     route: RxRoute = Field(
-        default=RxRoute.NONE,
-        description="What is the the route of administration for this medication?",
+        default=RxRoute.NONE_OF_THE_ABOVE,
+        description=(
+            "What is the route of administration for this medication? "
+            "PO: Oral (includes swallowed and sublingual routes); "
+            "NG: Nasogastric/Feeding tube (NG/PEG); "
+            "INJECTION: Injection (IV, SC, or IM); "
+            "INHALATION: Inhalation (respiratory route); "
+            "TOPICAL: Topical (skin or mucosal surface); "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
     phase: TreatmentPhase = Field(
-        default=TreatmentPhase.NONE, description="What is the treatment phase for this medication?"
+        default=TreatmentPhase.NONE_OF_THE_ABOVE,
+        description=(
+            "What is the treatment phase for this medication? "
+            "INDUCTION: Induction therapy; "
+            "MAINTENANCE: Maintenance therapy; "
+            "RESCUE: Rescue therapy; "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
     expected_supply_days: int | None = Field(
@@ -234,7 +328,15 @@ class MedicationMention(SpanAugmentedMention):
     )
 
     frequency: RxFrequency = Field(
-        default=RxFrequency.NONE, description="What is the frequency of this medication?"
+        default=RxFrequency.NONE_OF_THE_ABOVE,
+        description=(
+            "What is the frequency of this medication? "
+            "QD: once daily; BID: twice daily; TID: three times daily; QID: four times daily; "
+            "QOD: every other day; Q6H: every 6 hours; Q8H: every 8 hours; Q12H: every 12 hours; "
+            "WEEKLY: once weekly; Q2W: once every 2 weeks; Q4W: once every 4 weeks; MONTHLY: once monthly; "
+            "OTHER: non-standard frequency (use timing_text); "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
     start_date: str | None = Field(
@@ -246,11 +348,20 @@ class MedicationMention(SpanAugmentedMention):
     )
 
     quantity_unit: RxQuantityUnit = Field(
-        RxQuantityUnit.NONE, description="Medication prescribed unit"
+        RxQuantityUnit.NONE_OF_THE_ABOVE,
+        description=(
+            "Medication prescribed unit. "
+            "Mass: MG=mg, G=g, UG=ug (microgram), KG=kg; "
+            "Volume: ML=mL, L=L; "
+            "International Units: U=U, IU=[iU]; "
+            "Countable: TABLET, CAPSULE, PUFF, PATCH, SUPPOSITORY; "
+            "Ratios: MG_PER_ML, MG_PER_KG, U_PER_KG, UG_PER_KG_PER_MIN; "
+            "Time: H=hours, MIN=minutes, D=days; "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
     quantity_value: str | None = Field(
         None,
         description="Numeric amount of medication prescribed or administered (FHIR Quantity.value)",
     )
-

--- a/cumulus_library_kidney_transplant/llm/model/base.py
+++ b/cumulus_library_kidney_transplant/llm/model/base.py
@@ -2,12 +2,21 @@ from enum import StrEnum
 from pydantic import BaseModel, Field
 
 class SpanAugmentedMention(BaseModel):
+    """
+    A mention of a particular concept in the text, augmented with the character spans 
+    where the mention was found.
+    This allows for validation of LLM-generated findings, as well as the ability to link
+    mentions back to the original text for review and auditing purposes.
+    """
     has_mention: bool = Field(
-        False, description="Whether there is any mention of this variable in the text."
-    )
+        ...,
+        description='Indicates whether the concept was mentioned in the text.'
+    )   
     spans: list[str] = Field(
-        default_factory=list, description="The text spans where this variable is mentioned."
+        ...,
+        description='The verbatim text where this concept was mentioned.'
     )
+
 
 ##########################################################
 #

--- a/cumulus_library_kidney_transplant/llm/model/base.py
+++ b/cumulus_library_kidney_transplant/llm/model/base.py
@@ -28,24 +28,21 @@ class SpanAugmentedMention(BaseModel):
 # Timing related to MedicationRequest.frequency
 
 
+# QD: once daily (1x/day)
+# BID: twice daily (2x/day)
+# TID: three times daily (3x/day)
+# QID: four times daily (4x/day)
+# QOD: every other day (1/2x/day)
+# Q6H: every 6 hours (4x/day)
+# Q8H: every 8 hours (3x/day)
+# Q12H: every 12 hours (2x/day)
+# WEEKLY: once every 7 days
+# Q2W: once every 2 weeks (14 days)
+# Q4W: once every 4 weeks (28 days)
+# MONTHLY: once every 4 weeks (28 days)
+# OTHER: use timing_text for non-standard frequency
+# NONE_OF_THE_ABOVE: None of the above
 class RxFrequency(StrEnum):
-    """
-    QD: once daily (1x/day)
-    BID: twice daily (2x/day)
-    TID: three times daily (3x/day)
-    QID: four times daily (4x/day)
-    QOD: every other day (1/2x/day)
-    Q6H: every 6 hours (4x/day)
-    Q8H: every 8 hours (3x/day)
-    Q12H: every 12 hours (2x/day)
-    WEEKLY: once every 7 days
-    Q2W: once every 2 weeks (14 days)
-    Q4W: once every 4 weeks (28 days)
-    MONTHLY: once every 4 weeks (28 days)
-    OTHER: use timing_text for non-standard frequency
-    NONE_OF_THE_ABOVE: None of the above
-    """
-
     QD = "QD"
     BID = "BID"
     TID = "TID"
@@ -66,19 +63,19 @@ class RxFrequency(StrEnum):
 # MedicationRequest.status
 
 
+
+# ACTIVE: Medication order is active (currently prescribed and intended for ongoing use).
+# INTENDED: Medication is planned/ordered/prescribed but therapy has not yet started.
+# COMPLETED: Medication course is finished (all doses given or intended duration completed).
+# STOPPED: Medication was stopped or permanently discontinued before completion.
+# CANCELED: Medication order was canceled/withdrawn before any doses were administered.
+# ON_HOLD: Medication is temporarily paused (on-hold, suspended, or interrupted).
+# NONE_OF_THE_ABOVE: None of the above
 class RxStatus(StrEnum):
     """
     Medication Status (including Intent because chart review is NOT always identical to Med Request)
     https://build.fhir.org/valueset-medicationrequest-status.html
     https://build.fhir.org/valueset-medicationrequest-intent.html
-
-    ACTIVE: Medication order is active (currently prescribed and intended for ongoing use).
-    INTENDED: Medication is planned/ordered/prescribed but therapy has not yet started.
-    COMPLETED: Medication course is finished (all doses given or intended duration completed).
-    STOPPED: Medication was stopped or permanently discontinued before completion.
-    CANCELED: Medication order was canceled/withdrawn before any doses were administered.
-    ON_HOLD: Medication is temporarily paused (on-hold, suspended, or interrupted).
-    NONE_OF_THE_ABOVE: None of the above
     """
 
     ACTIVE = "ACTIVE"
@@ -94,14 +91,13 @@ class RxStatus(StrEnum):
 # MedicationRequest.category
 
 
+# INPATIENT: Medication ordered/administered during an inpatient/acute care setting
+# OUTPATIENT: Medication ordered/administered during an outpatient setting
+# COMMUNITY: Medication ordered/consumed by the patient in their home (including long term care, nursing homes, etc)
+# NONE_OF_THE_ABOVE: None of the above
 class RxCategory(StrEnum):
     """
     https://build.fhir.org/valueset-medicationrequest-admin-location.html
-
-    INPATIENT: Medication ordered/administered during an inpatient/acute care setting
-    OUTPATIENT: Medication ordered/administered during an outpatient setting
-    COMMUNITY: Medication ordered/consumed by the patient in their home (including long term care, nursing homes, etc)
-    NONE_OF_THE_ABOVE: None of the above
     """
 
     INPATIENT = "INPATIENT"
@@ -114,6 +110,12 @@ class RxCategory(StrEnum):
 # MedicationRequest.route
 
 
+# PO: Oral (includes swallowed and sublingual routes)
+# NG: Nasogastric/Feeding tube (NG/PEG)
+# INJECTION: Injection (IV, SC, or IM)
+# INHALATION: Inhalation (respiratory route)
+# TOPICAL: Topical (skin or mucosal surface)
+# NONE_OF_THE_ABOVE: None of the above
 class RxRoute(StrEnum):
     """
     Route of Administration can "help" (but not deterministic) for drug metadata, examples
@@ -121,13 +123,6 @@ class RxRoute(StrEnum):
     * Topical --> skin lesions
     * Inhalation --> Steroid
     https://build.fhir.org/valueset-route-codes.html
-
-    PO: Oral (includes swallowed and sublingual routes)
-    NG: Nasogastric/Feeding tube (NG/PEG)
-    INJECTION: Injection (IV, SC, or IM)
-    INHALATION: Inhalation (respiratory route)
-    TOPICAL: Topical (skin or mucosal surface)
-    NONE_OF_THE_ABOVE: None of the above
     """
 
     PO = "PO"
@@ -170,17 +165,16 @@ class RxValidityPeriodMention(SpanAugmentedMention):
     )
 
 
+# Mass: MG=mg, G=g, UG=ug (microgram/mcg), KG=kg
+# Volume: ML=mL, L=L
+# International Units: U=U, IU=[iU]
+# Countable: TABLET={tablet}, CAPSULE={capsule}, PUFF={puff}, PATCH={patch}, SUPPOSITORY={suppository}
+# Ratios: MG_PER_ML=mg/mL, MG_PER_KG=mg/kg, U_PER_KG=U/kg, UG_PER_KG_PER_MIN=ug/kg/min
+# Time (infusion rates): H=h, MIN=min, D=d
+# NONE_OF_THE_ABOVE: None of the above
 class RxQuantityUnit(StrEnum):
     """
     UCUM unit codes for medication quantity.
-
-    Mass: MG=mg, G=g, UG=ug (microgram/mcg), KG=kg
-    Volume: ML=mL, L=L
-    International Units: U=U, IU=[iU]
-    Countable: TABLET={tablet}, CAPSULE={capsule}, PUFF={puff}, PATCH={patch}, SUPPOSITORY={suppository}
-    Ratios: MG_PER_ML=mg/mL, MG_PER_KG=mg/kg, U_PER_KG=U/kg, UG_PER_KG_PER_MIN=ug/kg/min
-    Time (infusion rates): H=h, MIN=min, D=d
-    NONE_OF_THE_ABOVE: None of the above
     """
 
     # Mass
@@ -247,16 +241,11 @@ class RxQuantity(SpanAugmentedMention):
 # Treatment Phase
 
 
+# INDUCTION: Induction therapy``
+# MAINTENANCE: Maintenance therapy
+# RESCUE: Rescue therapy
+# NONE_OF_THE_ABOVE: None of the above
 class TreatmentPhase(StrEnum):
-    """
-    Treatment Phase
-
-    INDUCTION: Induction therapy
-    MAINTENANCE: Maintenance therapy
-    RESCUE: Rescue therapy
-    NONE_OF_THE_ABOVE: None of the above
-    """
-
     INDUCTION = "INDUCTION"
     MAINTENANCE = "MAINTENANCE"
     RESCUE = "RESCUE"

--- a/cumulus_library_kidney_transplant/llm/model/donor.py
+++ b/cumulus_library_kidney_transplant/llm/model/donor.py
@@ -1,5 +1,5 @@
-import json 
-import os 
+import json
+import os
 from enum import StrEnum
 
 from pydantic import BaseModel, Field
@@ -135,9 +135,15 @@ class DonorTransplantDateMention(SpanAugmentedMention):
 
 
 class DonorType(StrEnum):
-    LIVING = "Donor was alive at time of renal transplant"
-    DECEASED = "Donor was deceased at time of renal transplant"
-    NOT_MENTIONED = "Donor was not mentioned as living or deceased"
+    """
+    LIVING: Donor was alive at time of renal transplant
+    DECEASED: Donor was deceased at time of renal transplant
+    NOT_MENTIONED: Donor was not mentioned as living or deceased
+    """
+
+    LIVING = "LIVING"
+    DECEASED = "DECEASED"
+    NOT_MENTIONED = "NOT_MENTIONED"
 
 
 class DonorTypeMention(SpanAugmentedMention):
@@ -149,14 +155,25 @@ class DonorTypeMention(SpanAugmentedMention):
 
     donor_type: DonorType = Field(
         DonorType.NOT_MENTIONED,
-        description="Was the first renal donor living at the time of renal transplant?",
+        description=(
+            "Was the first renal donor living at the time of renal transplant? "
+            "LIVING: Donor was alive at time of renal transplant; "
+            "DECEASED: Donor was deceased at time of renal transplant; "
+            "NOT_MENTIONED: Donor was not mentioned as living or deceased"
+        ),
     )
 
 
 class DonorRelationship(StrEnum):
-    RELATED = "Donor was biologically related to the renal transplant recipient"
-    UNRELATED = "Donor was biologically unrelated to the renal transplant recipient"
-    NOT_MENTIONED = "Donor relationship status was not mentioned"
+    """
+    RELATED: Donor was biologically related to the renal transplant recipient
+    UNRELATED: Donor was biologically unrelated to the renal transplant recipient
+    NOT_MENTIONED: Donor relationship status was not mentioned
+    """
+
+    RELATED = "RELATED"
+    UNRELATED = "UNRELATED"
+    NOT_MENTIONED = "NOT_MENTIONED"
 
 
 class DonorRelationshipMention(SpanAugmentedMention):
@@ -168,17 +185,27 @@ class DonorRelationshipMention(SpanAugmentedMention):
 
     donor_relationship: DonorRelationship = Field(
         DonorRelationship.NOT_MENTIONED,
-        description="Was the first renal transplant donor biologically related to the recipient?",
+        description=(
+            "Was the first renal transplant donor biologically related to the recipient? "
+            "RELATED: Donor was biologically related to the renal transplant recipient; "
+            "UNRELATED: Donor was biologically unrelated to the renal transplant recipient; "
+            "NOT_MENTIONED: Donor relationship status was not mentioned"
+        ),
     )
 
 
 class DonorHlaMatchQuality(StrEnum):
-    WELL = "Well matched (0-1 mismatches) OR recipient explicitly documented as not sensitized"
-    MODERATE = (
-        "Moderately matched (2-4 mismatches) OR recipient explicitly documented as sensitized"
-    )
-    POOR = "Poorly matched (5-6 mismatches) OR recipient explicitly documented as highly sensitized"
-    NOT_MENTIONED = "HLA match quality not mentioned"
+    """
+    WELL: Well matched (0-1 mismatches) OR recipient explicitly documented as not sensitized
+    MODERATE: Moderately matched (2-4 mismatches) OR recipient explicitly documented as sensitized
+    POOR: Poorly matched (5-6 mismatches) OR recipient explicitly documented as highly sensitized
+    NOT_MENTIONED: HLA match quality not mentioned
+    """
+
+    WELL = "WELL"
+    MODERATE = "MODERATE"
+    POOR = "POOR"
+    NOT_MENTIONED = "NOT_MENTIONED"
 
 
 class DonorHlaMatchQualityMention(SpanAugmentedMention):
@@ -189,19 +216,38 @@ class DonorHlaMatchQualityMention(SpanAugmentedMention):
 
     donor_hla_match_quality: DonorHlaMatchQuality = Field(
         DonorHlaMatchQuality.NOT_MENTIONED,
-        description="What was the HLA match quality for the first renal transplant?",
+        description=(
+            "What was the HLA match quality for the first renal transplant? "
+            "WELL: Well matched (0-1 mismatches) OR recipient explicitly documented as not sensitized; "
+            "MODERATE: Moderately matched (2-4 mismatches) OR recipient explicitly documented as sensitized; "
+            "POOR: Poorly matched (5-6 mismatches) OR recipient explicitly documented as highly sensitized; "
+            "NOT_MENTIONED: HLA match quality not mentioned"
+        ),
     )
 
 
 class DonorHlaMismatchCount(StrEnum):
-    ZERO = "0"
-    ONE = "1"
-    TWO = "2"
-    THREE = "3"
-    FOUR = "4"
-    FIVE = "5"
-    SIX = "6"
-    NOT_MENTIONED = "HLA mismatch count not mentioned"
+    """
+    Number of HLA mismatches between donor and recipient.
+
+    ZERO: 0 mismatches
+    ONE: 1 mismatch
+    TWO: 2 mismatches
+    THREE: 3 mismatches
+    FOUR: 4 mismatches
+    FIVE: 5 mismatches
+    SIX: 6 mismatches
+    NOT_MENTIONED: HLA mismatch count not mentioned
+    """
+
+    ZERO = "ZERO"
+    ONE = "ONE"
+    TWO = "TWO"
+    THREE = "THREE"
+    FOUR = "FOUR"
+    FIVE = "FIVE"
+    SIX = "SIX"
+    NOT_MENTIONED = "NOT_MENTIONED"
 
 
 class DonorHlaMismatchCountMention(SpanAugmentedMention):
@@ -212,7 +258,17 @@ class DonorHlaMismatchCountMention(SpanAugmentedMention):
 
     donor_hla_mismatch_count: DonorHlaMismatchCount = Field(
         DonorHlaMismatchCount.NOT_MENTIONED,
-        description="What was the donor-recipient HLA mismatch count for the first renal transplant?",
+        description=(
+            "What was the donor-recipient HLA mismatch count for the first renal transplant? "
+            "ZERO: 0 mismatches; "
+            "ONE: 1 mismatch; "
+            "TWO: 2 mismatches; "
+            "THREE: 3 mismatches; "
+            "FOUR: 4 mismatches; "
+            "FIVE: 5 mismatches; "
+            "SIX: 6 mismatches; "
+            "NOT_MENTIONED: HLA mismatch count not mentioned"
+        ),
     )
 
 
@@ -247,8 +303,3 @@ class KidneyTransplantDonorGroupAnnotation(BaseModel):
     recipient_serostatus_ebv_mention: SerostatusRecipientEBVMention
 
 
-if __name__ == "__main__":
-    basedir = os.path.dirname(__file__)
-
-    with open(f"{basedir}/schemas/irae_donor.json", "w", encoding="utf8") as f:
-        json.dump(KidneyTransplantDonorGroupAnnotation.model_json_schema(), f, indent=2)

--- a/cumulus_library_kidney_transplant/llm/model/donor.py
+++ b/cumulus_library_kidney_transplant/llm/model/donor.py
@@ -1,5 +1,3 @@
-import json
-import os
 from enum import StrEnum
 
 from pydantic import BaseModel, Field

--- a/cumulus_library_kidney_transplant/llm/model/donor.py
+++ b/cumulus_library_kidney_transplant/llm/model/donor.py
@@ -12,15 +12,13 @@ from cumulus_library_kidney_transplant.llm.model.base import SpanAugmentedMentio
 # For a given transplant, these should be static over time
 ###############################################################################
 
-
+# SEROPOSITIVE: Documented IgG positive / seropositive
+# SERONEGATIVE: Documented IgG negative / seronegative
+# NOT_MENTIONED: No serostatus documentation found
 class Serostatus(StrEnum):
     """
     Serostatus classification based on IgG serology or explicit seropositive/seronegative statements.
-    - SEROPOSITIVE: Documented IgG positive / seropositive
-    - SERONEGATIVE: Documented IgG negative / seronegative
-    - NOT_MENTIONED: No serostatus documentation found
     """
-
     SEROPOSITIVE = "SEROPOSITIVE"
     SERONEGATIVE = "SERONEGATIVE"
     NOT_MENTIONED = "NOT_MENTIONED"
@@ -30,11 +28,13 @@ class SerostatusDonorMention(SpanAugmentedMention):
     """
     Overall serostatus of the donor at the time of first renal transplant.
     """
-
     serostatus: Serostatus = Field(
         Serostatus.NOT_MENTIONED,
         description=(
             "Overall serostatus of the renal donor for ANY virus. "
+            "SEROPOSITIVE: Documented IgG positive / seropositive"
+            "SERONEGATIVE: Documented IgG negative / seronegative"
+            "NOT_MENTIONED: No serostatus documentation found"
             "Set SEROPOSITIVE if the note documents the donor as seropositive for "
             "ANY virus (including CMV, EBV, HBV, HCV, HSV, VZV, or an unspecified virus), "
             "or uses generic language such as 'donor is seropositive' without naming the virus. "
@@ -48,11 +48,13 @@ class SerostatusDonorCMVMention(SpanAugmentedMention):
     """
     CMV serostatus of the donor at the time of first renal transplant.
     """
-
     serostatus: Serostatus = Field(
         Serostatus.NOT_MENTIONED,
         description=(
             "CMV serostatus of the renal donor. Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. "
+            "SEROPOSITIVE: Documented IgG positive / seropositive"
+            "SERONEGATIVE: Documented IgG negative / seronegative"
+            "NOT_MENTIONED: No serostatus documentation found"
             "Look for patterns like 'CMV D+', 'CMV D-', 'donor CMV IgG positive', 'donor CMV IgG negative', etc."
         ),
     )
@@ -62,11 +64,13 @@ class SerostatusDonorEBVMention(SpanAugmentedMention):
     """
     EBV serostatus of the donor at the time of first renal transplant.
     """
-
     serostatus: Serostatus = Field(
         Serostatus.NOT_MENTIONED,
         description=(
             "EBV serostatus of the renal donor. Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. "
+            "SEROPOSITIVE: Documented IgG positive / seropositive"
+            "SERONEGATIVE: Documented IgG negative / seronegative"
+            "NOT_MENTIONED: No serostatus documentation found"
             "Look for patterns like 'EBV D+', 'EBV D-', 'donor EBV IgG positive', 'donor EBV IgG negative', etc."
         ),
     )
@@ -76,11 +80,13 @@ class SerostatusRecipientMention(SpanAugmentedMention):
     """
     Overall serostatus of the recipient at the time of first renal transplant.
     """
-
     serostatus: Serostatus = Field(
         Serostatus.NOT_MENTIONED,
         description=(
             "Serostatus of the recipient at the time of renal transplant for ANY virus. "
+            "SEROPOSITIVE: Documented IgG positive / seropositive"
+            "SERONEGATIVE: Documented IgG negative / seronegative"
+            "NOT_MENTIONED: No serostatus documentation found"
             "Set SEROPOSITIVE if the note documents the recipient as seropositive for "
             "ANY virus (including CMV, EBV, HBV, HCV, HSV, VZV, or an unspecified virus), "
             "or if the text states 'recipient is seropositive' without naming the virus. "
@@ -94,11 +100,13 @@ class SerostatusRecipientCMVMention(SpanAugmentedMention):
     """
     CMV serostatus of the recipient at the time of first renal transplant.
     """
-
     serostatus: Serostatus = Field(
         Serostatus.NOT_MENTIONED,
         description=(
             "CMV serostatus of the recipient at the time of renal transplant. "
+            "SEROPOSITIVE: Documented IgG positive / seropositive"
+            "SERONEGATIVE: Documented IgG negative / seronegative"
+            "NOT_MENTIONED: No serostatus documentation found"
             "Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. "
             "Look for patterns like 'CMV R+', 'CMV R-', 'recipient CMV IgG positive', 'recipient CMV IgG negative', etc."
         ),
@@ -109,11 +117,13 @@ class SerostatusRecipientEBVMention(SpanAugmentedMention):
     """
     EBV serostatus of the recipient at the time of first renal transplant.
     """
-
     serostatus: Serostatus = Field(
         Serostatus.NOT_MENTIONED,
         description=(
             "EBV serostatus of the recipient at the time of renal transplant. "
+            "SEROPOSITIVE: Documented IgG positive / seropositive"
+            "SERONEGATIVE: Documented IgG negative / seronegative"
+            "NOT_MENTIONED: No serostatus documentation found"
             "Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. "
             "Look for patterns like 'EBV R+', 'EBV R-', 'recipient EBV IgG positive', 'recipient EBV IgG negative', etc."
         ),
@@ -134,13 +144,10 @@ class DonorTransplantDateMention(SpanAugmentedMention):
     )
 
 
+# LIVING: Donor was alive at time of renal transplant
+# DECEASED: Donor was deceased at time of renal transplant
+# NOT_MENTIONED: Donor was not mentioned as living or deceased
 class DonorType(StrEnum):
-    """
-    LIVING: Donor was alive at time of renal transplant
-    DECEASED: Donor was deceased at time of renal transplant
-    NOT_MENTIONED: Donor was not mentioned as living or deceased
-    """
-
     LIVING = "LIVING"
     DECEASED = "DECEASED"
     NOT_MENTIONED = "NOT_MENTIONED"
@@ -163,14 +170,10 @@ class DonorTypeMention(SpanAugmentedMention):
         ),
     )
 
-
+# RELATED: Donor was biologically related to the renal transplant recipient
+# UNRELATED: Donor was biologically unrelated to the renal transplant recipient
+# NOT_MENTIONED: Donor relationship status was not mentioned
 class DonorRelationship(StrEnum):
-    """
-    RELATED: Donor was biologically related to the renal transplant recipient
-    UNRELATED: Donor was biologically unrelated to the renal transplant recipient
-    NOT_MENTIONED: Donor relationship status was not mentioned
-    """
-
     RELATED = "RELATED"
     UNRELATED = "UNRELATED"
     NOT_MENTIONED = "NOT_MENTIONED"
@@ -194,14 +197,11 @@ class DonorRelationshipMention(SpanAugmentedMention):
     )
 
 
+# WELL: Well matched (0-1 mismatches) OR recipient explicitly documented as not sensitized
+# MODERATE: Moderately matched (2-4 mismatches) OR recipient explicitly documented as sensitized
+# POOR: Poorly matched (5-6 mismatches) OR recipient explicitly documented as highly sensitized
+# NOT_MENTIONED: HLA match quality not mentioned
 class DonorHlaMatchQuality(StrEnum):
-    """
-    WELL: Well matched (0-1 mismatches) OR recipient explicitly documented as not sensitized
-    MODERATE: Moderately matched (2-4 mismatches) OR recipient explicitly documented as sensitized
-    POOR: Poorly matched (5-6 mismatches) OR recipient explicitly documented as highly sensitized
-    NOT_MENTIONED: HLA match quality not mentioned
-    """
-
     WELL = "WELL"
     MODERATE = "MODERATE"
     POOR = "POOR"
@@ -226,18 +226,18 @@ class DonorHlaMatchQualityMention(SpanAugmentedMention):
     )
 
 
+
+# ZERO: 0 mismatches
+# ONE: 1 mismatch
+# TWO: 2 mismatches
+# THREE: 3 mismatches
+# FOUR: 4 mismatches
+# FIVE: 5 mismatches
+# SIX: 6 mismatches
+# NOT_MENTIONED: HLA mismatch count not mentioned
 class DonorHlaMismatchCount(StrEnum):
     """
     Number of HLA mismatches between donor and recipient.
-
-    ZERO: 0 mismatches
-    ONE: 1 mismatch
-    TWO: 2 mismatches
-    THREE: 3 mismatches
-    FOUR: 4 mismatches
-    FIVE: 5 mismatches
-    SIX: 6 mismatches
-    NOT_MENTIONED: HLA mismatch count not mentioned
     """
 
     ZERO = "ZERO"

--- a/cumulus_library_kidney_transplant/llm/model/medication.py
+++ b/cumulus_library_kidney_transplant/llm/model/medication.py
@@ -1,5 +1,3 @@
-import json
-import os
 from enum import StrEnum
 
 from pydantic import BaseModel, Field

--- a/cumulus_library_kidney_transplant/llm/model/medication.py
+++ b/cumulus_library_kidney_transplant/llm/model/medication.py
@@ -1,4 +1,4 @@
-import json 
+import json
 import os
 from enum import StrEnum
 
@@ -13,61 +13,82 @@ from cumulus_library_kidney_transplant.llm.model.base import MedicationMention
 ##########################################################
 class RxClassImmunosuppression(StrEnum):
     """
-    RxClass Immunosuppression
+    Immunosuppressive drug class or therapy modality.
+
+    ANTIMET: Anti-Metabolite (e.g., azathioprine, mycophenolate)
+    CNI: Calcineurin Inhibitor (e.g., tacrolimus, cyclosporine)
+    STEROID: Corticosteroid (e.g., prednisone, methylprednisolone)
+    MTOR: mTOR Inhibitor (e.g., sirolimus, everolimus)
+    COSTIM: Costimulation Blocker/blockade (e.g., belatacept)
+    IVIG: Immunoglobulin (e.g., IVIG, Cytogam)
+    POLYCLONAL: Polyclonal antibody (e.g., ATG, ALG)
+    MONOCLONAL: Monoclonal antibody (mAb, e.g., basiliximab, rituximab)
+    OTHER: Other immunosuppressive drug
+    NONE: None of the above
     """
 
-    ANTIMET = "Anti-Metabolite (ANTIMET)"
-    CNI = "Calcineurin Inhibitor (CNI)"
-    STEROID = "Corticosteroid (CS)"
-    MTOR = "mTOR Inhibitor (MTOR)"
-    COSTIM = "Costimulation Blocker/blockade (COSTIM)"
-    IVIG = "Immunoglobulin (IVIG)"
-    POLYCLONAL = "Polyclonal antibody (e.g., ATG, ALG)"
-    MONOCLONAL = "Monoclonal antibody (mAb, e.g., basiliximab, rituximab)"
-    OTHER = "Other immunosuppressive drug"
-    NONE = "None of the above"
+    ANTIMET = "ANTIMET"
+    CNI = "CNI"
+    STEROID = "STEROID"
+    MTOR = "MTOR"
+    COSTIM = "COSTIM"
+    IVIG = "IVIG"
+    POLYCLONAL = "POLYCLONAL"
+    MONOCLONAL = "MONOCLONAL"
+    OTHER = "OTHER"
+    NONE = "NONE"
 
 
 class RxIngredientImmunosuppression(StrEnum):
     """
-    The specific immunosuppressive drug ingredient
+    The specific immunosuppressive drug ingredient.
+
+    ANTIMET group: AZA=Azathioprine, MMF=Mycophenolate Mofetil, ANTIMET_OTHER=Other anti-metabolite
+    CNI group: CYA=Cyclosporine, TAC=Tacrolimus, CNI_OTHER=Other calcineurin inhibitor
+    STEROID group: MEDROL=Methylprednisolone, PDL=Prednisolone, PRED=Prednisone, STEROID_OTHER=Other corticosteroid
+    COSTIM group: BEL=Belatacept, ABA=Abatacept, COSTIM_OTHER=Other costimulation blocker
+    IVIG group: IVIG=Intravenous Immunoglobulin, CYTOGAM=Cytogam (CMV-specific hyperimmune globulin), IVIG_OTHER=Other immunoglobulin
+    MTOR group: EVE=Everolimus, SRL=Sirolimus, MTOR_OTHER=Other mTOR inhibitor
+    MONOCLONAL group: ALEM=Alemtuzumab, BASI=Basiliximab, DAC=Daclizumab, RTX=Rituximab, MONOCLONAL_OTHER=Other monoclonal antibody
+    POLYCLONAL group: ATG=Antithymocyte Globulin, POLYCLONAL_OTHER=Other polyclonal antibody
+    NONE: None of the above
     """
 
     # ANTIMET Types
-    AZA = "Azathioprine"
-    MMF = "Mycophenolate Mofetil"
-    ANTIMET_OTHER = "Other anti-metabolite ingredient"
+    AZA = "AZA"
+    MMF = "MMF"
+    ANTIMET_OTHER = "ANTIMET_OTHER"
     # CNI Types
-    CYA = "Cyclosporine"
-    TAC = "Tacrolimus"
-    CNI_OTHER = "Other calcineurin inhibitor ingredient"
+    CYA = "CYA"
+    TAC = "TAC"
+    CNI_OTHER = "CNI_OTHER"
     # STEROID Types
-    MEDROL = "Methylprednisolone"
-    PDL = "Prednisolone"
-    PRED = "Prednisone"
-    STEROID_OTHER = "Other corticosteroid ingredient"
+    MEDROL = "MEDROL"
+    PDL = "PDL"
+    PRED = "PRED"
+    STEROID_OTHER = "STEROID_OTHER"
     # COSTIM Types
-    BEL = "Belatacept"
-    ABA = "Abatacept"
-    COSTIM_OTHER = "Other Costimulation blocker ingredient"
+    BEL = "BEL"
+    ABA = "ABA"
+    COSTIM_OTHER = "COSTIM_OTHER"
     # IVIG Types
-    IVIG = "Intravenous Immunoglobulin (IVIG)"
-    CYTOGAM = "Cytogam (CMV-specific hyperimmune globulin)"
-    IVIG_OTHER = "Other immunoglobulin therapy"
+    IVIG = "IVIG"
+    CYTOGAM = "CYTOGAM"
+    IVIG_OTHER = "IVIG_OTHER"
     # MTOR Types
-    EVE = "Everolimus"
-    SRL = "Sirolimus"
-    MTOR_OTHER = "Other mTOR inhibitor ingredient"
+    EVE = "EVE"
+    SRL = "SRL"
+    MTOR_OTHER = "MTOR_OTHER"
     # MONOCLONAL Types
-    ALEM = "Alemtuzumab"
-    BASI = "Basiliximab"
-    DAC = "Daclizumab"
-    RTX = "Rituximab"
-    MONOCLONAL_OTHER = "Other Monoclonal antibody drug"
+    ALEM = "ALEM"
+    BASI = "BASI"
+    DAC = "DAC"
+    RTX = "RTX"
+    MONOCLONAL_OTHER = "MONOCLONAL_OTHER"
     # POLYCLONAL Types
-    ATG = "Antithymocyte Globulin (ATG)"
-    POLYCLONAL_OTHER = "Other polyclonal antibodies ingredient"
-    NONE = "None of the above"
+    ATG = "ATG"
+    POLYCLONAL_OTHER = "POLYCLONAL_OTHER"
+    NONE = "NONE"
 
 
 
@@ -78,12 +99,35 @@ class ImmunosuppressiveMedicationMention(MedicationMention):
 
     drug_class: RxClassImmunosuppression = Field(
         default=RxClassImmunosuppression.NONE,
-        description="Extract the Immunosuppressive drug class or therapy modality documented for this medication, if present",
+        description=(
+            "Extract the Immunosuppressive drug class or therapy modality documented for this medication, if present. "
+            "ANTIMET: Anti-Metabolite (e.g., azathioprine, mycophenolate); "
+            "CNI: Calcineurin Inhibitor (e.g., tacrolimus, cyclosporine); "
+            "STEROID: Corticosteroid (e.g., prednisone, methylprednisolone); "
+            "MTOR: mTOR Inhibitor (e.g., sirolimus, everolimus); "
+            "COSTIM: Costimulation Blocker/blockade (e.g., belatacept); "
+            "IVIG: Immunoglobulin (e.g., IVIG, Cytogam); "
+            "POLYCLONAL: Polyclonal antibody (e.g., ATG, ALG); "
+            "MONOCLONAL: Monoclonal antibody (e.g., basiliximab, rituximab); "
+            "OTHER: Other immunosuppressive drug; "
+            "NONE: None of the above"
+        ),
     )
 
     ingredient: RxIngredientImmunosuppression = Field(
         default=RxIngredientImmunosuppression.NONE,
-        description="Extract the specific immunosuppressive drug ingredient documented for this medication, if present",
+        description=(
+            "Extract the specific immunosuppressive drug ingredient documented for this medication, if present. "
+            "ANTIMET group: AZA=Azathioprine, MMF=Mycophenolate Mofetil, ANTIMET_OTHER=other anti-metabolite; "
+            "CNI group: CYA=Cyclosporine, TAC=Tacrolimus, CNI_OTHER=other calcineurin inhibitor; "
+            "STEROID group: MEDROL=Methylprednisolone, PDL=Prednisolone, PRED=Prednisone, STEROID_OTHER=other corticosteroid; "
+            "COSTIM group: BEL=Belatacept, ABA=Abatacept, COSTIM_OTHER=other costimulation blocker; "
+            "IVIG group: IVIG=Intravenous Immunoglobulin, CYTOGAM=Cytogam (CMV-specific hyperimmune globulin), IVIG_OTHER=other immunoglobulin; "
+            "MTOR group: EVE=Everolimus, SRL=Sirolimus, MTOR_OTHER=other mTOR inhibitor; "
+            "MONOCLONAL group: ALEM=Alemtuzumab, BASI=Basiliximab, DAC=Daclizumab, RTX=Rituximab, MONOCLONAL_OTHER=other monoclonal antibody; "
+            "POLYCLONAL group: ATG=Antithymocyte Globulin, POLYCLONAL_OTHER=other polyclonal antibody; "
+            "NONE: None of the above"
+        ),
     )
 
 
@@ -103,10 +147,3 @@ class ImmunosuppressiveMedicationsAnnotation(BaseModel):
         default_factory=list,
         description="All mentions of ImmunosuppressiveMedications for this given chart.",
     )
-
-
-if __name__ == "__main__":
-    basedir = os.path.dirname(__file__)
-
-    with open(f"{basedir}/schemas/irae_medications.json", "w", encoding="utf8") as f:
-        json.dump(ImmunosuppressiveMedicationMention.model_json_schema(), f, indent=2)

--- a/cumulus_library_kidney_transplant/llm/model/medication.py
+++ b/cumulus_library_kidney_transplant/llm/model/medication.py
@@ -11,22 +11,21 @@ from cumulus_library_kidney_transplant.llm.model.base import MedicationMention
 #           Immunosuppression ** DRUG CLASS **
 #
 ##########################################################
+
+# ANTIMET: Anti-Metabolite (e.g., azathioprine, mycophenolate)
+# CNI: Calcineurin Inhibitor (e.g., tacrolimus, cyclosporine)
+# STEROID: Corticosteroid (e.g., prednisone, methylprednisolone)
+# MTOR: mTOR Inhibitor (e.g., sirolimus, everolimus)
+# COSTIM: Costimulation Blocker/blockade (e.g., belatacept)
+# IVIG: Immunoglobulin (e.g., IVIG, Cytogam)
+# POLYCLONAL: Polyclonal antibody (e.g., ATG, ALG)
+# MONOCLONAL: Monoclonal antibody (mAb, e.g., basiliximab, rituximab)
+# OTHER: Other immunosuppressive drug
+# NONE: None of the above
 class RxClassImmunosuppression(StrEnum):
     """
     Immunosuppressive drug class or therapy modality.
-
-    ANTIMET: Anti-Metabolite (e.g., azathioprine, mycophenolate)
-    CNI: Calcineurin Inhibitor (e.g., tacrolimus, cyclosporine)
-    STEROID: Corticosteroid (e.g., prednisone, methylprednisolone)
-    MTOR: mTOR Inhibitor (e.g., sirolimus, everolimus)
-    COSTIM: Costimulation Blocker/blockade (e.g., belatacept)
-    IVIG: Immunoglobulin (e.g., IVIG, Cytogam)
-    POLYCLONAL: Polyclonal antibody (e.g., ATG, ALG)
-    MONOCLONAL: Monoclonal antibody (mAb, e.g., basiliximab, rituximab)
-    OTHER: Other immunosuppressive drug
-    NONE: None of the above
     """
-
     ANTIMET = "ANTIMET"
     CNI = "CNI"
     STEROID = "STEROID"
@@ -39,19 +38,19 @@ class RxClassImmunosuppression(StrEnum):
     NONE = "NONE"
 
 
+
+# ANTIMET group: AZA=Azathioprine, MMF=Mycophenolate Mofetil, ANTIMET_OTHER=Other anti-metabolite
+# CNI group: CYA=Cyclosporine, TAC=Tacrolimus, CNI_OTHER=Other calcineurin inhibitor
+# STEROID group: MEDROL=Methylprednisolone, PDL=Prednisolone, PRED=Prednisone, STEROID_OTHER=Other corticosteroid
+# COSTIM group: BEL=Belatacept, ABA=Abatacept, COSTIM_OTHER=Other costimulation blocker
+# IVIG group: IVIG=Intravenous Immunoglobulin, CYTOGAM=Cytogam (CMV-specific hyperimmune globulin), IVIG_OTHER=Other immunoglobulin
+# MTOR group: EVE=Everolimus, SRL=Sirolimus, MTOR_OTHER=Other mTOR inhibitor
+# MONOCLONAL group: ALEM=Alemtuzumab, BASI=Basiliximab, DAC=Daclizumab, RTX=Rituximab, MONOCLONAL_OTHER=Other monoclonal antibody
+# POLYCLONAL group: ATG=Antithymocyte Globulin, POLYCLONAL_OTHER=Other polyclonal antibody
+# NONE: None of the above
 class RxIngredientImmunosuppression(StrEnum):
     """
     The specific immunosuppressive drug ingredient.
-
-    ANTIMET group: AZA=Azathioprine, MMF=Mycophenolate Mofetil, ANTIMET_OTHER=Other anti-metabolite
-    CNI group: CYA=Cyclosporine, TAC=Tacrolimus, CNI_OTHER=Other calcineurin inhibitor
-    STEROID group: MEDROL=Methylprednisolone, PDL=Prednisolone, PRED=Prednisone, STEROID_OTHER=Other corticosteroid
-    COSTIM group: BEL=Belatacept, ABA=Abatacept, COSTIM_OTHER=Other costimulation blocker
-    IVIG group: IVIG=Intravenous Immunoglobulin, CYTOGAM=Cytogam (CMV-specific hyperimmune globulin), IVIG_OTHER=Other immunoglobulin
-    MTOR group: EVE=Everolimus, SRL=Sirolimus, MTOR_OTHER=Other mTOR inhibitor
-    MONOCLONAL group: ALEM=Alemtuzumab, BASI=Basiliximab, DAC=Daclizumab, RTX=Rituximab, MONOCLONAL_OTHER=Other monoclonal antibody
-    POLYCLONAL group: ATG=Antithymocyte Globulin, POLYCLONAL_OTHER=Other polyclonal antibody
-    NONE: None of the above
     """
 
     # ANTIMET Types

--- a/cumulus_library_kidney_transplant/llm/model/outcome.py
+++ b/cumulus_library_kidney_transplant/llm/model/outcome.py
@@ -11,18 +11,29 @@ from cumulus_library_kidney_transplant.llm.model.base import SpanAugmentedMentio
 # Therapeutic Status Compliance
 ###############################################################################
 class RxTherapeuticStatus(StrEnum):
-    THERAPEUTIC = (
-        "Immunosuppression levels are documented as therapeutic, adequate, or within target range."
-    )
-    SUB_THERAPEUTIC = "Immunosuppression levels are documented as subtherapeutic, insufficient, or below target range."
-    SUPRA_THERAPEUTIC = "Immunosuppression levels are documented as supratherapeutic, above therapeutic level, or above target range."
-    NONE_OF_THE_ABOVE = "None of the above"
+    """
+    THERAPEUTIC: Immunosuppression levels are documented as therapeutic, adequate, or within target range.
+    SUB_THERAPEUTIC: Immunosuppression levels are documented as subtherapeutic, insufficient, or below target range.
+    SUPRA_THERAPEUTIC: Immunosuppression levels are documented as supratherapeutic, above therapeutic level, or above target range.
+    NONE_OF_THE_ABOVE: None of the above
+    """
+
+    THERAPEUTIC = "THERAPEUTIC"
+    SUB_THERAPEUTIC = "SUB_THERAPEUTIC"
+    SUPRA_THERAPEUTIC = "SUPRA_THERAPEUTIC"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 class RxTherapeuticStatusMention(SpanAugmentedMention):
     rx_therapeutic_status: RxTherapeuticStatus = Field(
         RxTherapeuticStatus.NONE_OF_THE_ABOVE,
-        description="In the present encounter, what is the documented immunosuppression level?",
+        description=(
+            "In the present encounter, what is the documented immunosuppression level? "
+            "THERAPEUTIC: Immunosuppression levels are documented as therapeutic, adequate, or within target range; "
+            "SUB_THERAPEUTIC: Immunosuppression levels are documented as subtherapeutic, insufficient, or below target range; "
+            "SUPRA_THERAPEUTIC: Immunosuppression levels are documented as supratherapeutic, above therapeutic level, or above target range; "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
 
@@ -30,18 +41,29 @@ class RxTherapeuticStatusMention(SpanAugmentedMention):
 # Medication Compliance
 ###############################################################################
 class RxCompliance(StrEnum):
-    COMPLIANT = "Patient is documented as compliant with immunosuppressive medications."
-    PARTIALLY_COMPLIANT = (
-        "Patient is documented as only partially compliant with immunosuppressive medications."
-    )
-    NON_COMPLIANT = "Patient is documented as noncompliant with immunosuppressive medications."
-    NONE_OF_THE_ABOVE = "None of the above"
+    """
+    COMPLIANT: Patient is documented as compliant with immunosuppressive medications.
+    PARTIALLY_COMPLIANT: Patient is documented as only partially compliant with immunosuppressive medications.
+    NON_COMPLIANT: Patient is documented as noncompliant with immunosuppressive medications.
+    NONE_OF_THE_ABOVE: None of the above
+    """
+
+    COMPLIANT = "COMPLIANT"
+    PARTIALLY_COMPLIANT = "PARTIALLY_COMPLIANT"
+    NON_COMPLIANT = "NON_COMPLIANT"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 class RxComplianceMention(SpanAugmentedMention):
     rx_compliance: RxCompliance = Field(
         RxCompliance.NONE_OF_THE_ABOVE,
-        description="In the present encounter, is the patient documented as compliant with immunosuppressive medications?",
+        description=(
+            "In the present encounter, is the patient documented as compliant with immunosuppressive medications? "
+            "COMPLIANT: Patient is documented as compliant with immunosuppressive medications; "
+            "PARTIALLY_COMPLIANT: Patient is documented as only partially compliant with immunosuppressive medications; "
+            "NON_COMPLIANT: Patient is documented as noncompliant with immunosuppressive medications; "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
 
@@ -64,13 +86,17 @@ class DSAPresent(StrEnum):
     as many of immunosuppressive drugs are routinely used for "maintenance" therapy.
 
     IVIG and plasmapheresis (PLEX) during the post-transplant (post induction) phase DOES imply
-    --> DSAPresent >  SUSPECTED (and possibly CONFIRMED)
+    --> DSAPresent > SUSPECTED (and possibly CONFIRMED)
     --> `GraftRejectionPresent` > SUSPECTED (and possibly CONFIRMED or BIOPSY_PROVEN)
+
+    CONFIRMED: DSA diagnostic test positive, DSA diagnosis 'confirmed' or 'positive', or increase in immunosuppression due to DSA
+    SUSPECTED: DSA suspected, DSA likely, DSA cannot be ruled out, DSA test result pending, or treatment with IVIG/plasmapheresis
+    NONE_OF_THE_ABOVE: None of the above
     """
 
-    CONFIRMED = "DSA diagnostic test positive, DSA diagnosis 'confirmed' or 'positive', or increase in immunosuppression due to DSA"
-    SUSPECTED = "DSA suspected, DSA likely, DSA cannot be ruled out, DSA test result pending, or treatment with IVIG/plasmapheresis"
-    NONE_OF_THE_ABOVE = "None of the above"
+    CONFIRMED = "CONFIRMED"
+    SUSPECTED = "SUSPECTED"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 class DSAMention(SpanAugmentedMention):
@@ -80,7 +106,12 @@ class DSAMention(SpanAugmentedMention):
     )
     dsa: DSAPresent = Field(
         DSAPresent.NONE_OF_THE_ABOVE,
-        description="What evidence documents donor specific antibodies (DSA) as current, active, or being evaluated/treated now?",
+        description=(
+            "What evidence documents donor specific antibodies (DSA) as current, active, or being evaluated/treated now? "
+            "CONFIRMED: DSA diagnostic test positive, DSA diagnosis 'confirmed' or 'positive', or increase in immunosuppression due to DSA; "
+            "SUSPECTED: DSA suspected, DSA likely, DSA cannot be ruled out, DSA test result pending, or treatment with IVIG/plasmapheresis; "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
 
@@ -90,9 +121,15 @@ class DSAMention(SpanAugmentedMention):
 #   * useful as a secondary check to ensure more specific infection types are not missed
 ############################################################################################################
 class InfectionPresent(StrEnum):
-    CONFIRMED = "Infection confirmed by laboratory test or imaging, infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to infection"
-    SUSPECTED = "Infection is suspected, likely, cannot be ruled out, infection is a differential diagnosis or infectious test result is pending"
-    NONE_OF_THE_ABOVE = "None of the above"
+    """
+    CONFIRMED: Infection confirmed by laboratory test or imaging, infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to infection
+    SUSPECTED: Infection is suspected, likely, cannot be ruled out, infection is a differential diagnosis or infectious test result is pending
+    NONE_OF_THE_ABOVE: None of the above
+    """
+
+    CONFIRMED = "CONFIRMED"
+    SUSPECTED = "SUSPECTED"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 class InfectionMention(SpanAugmentedMention):
@@ -101,7 +138,12 @@ class InfectionMention(SpanAugmentedMention):
     )
     infection: InfectionPresent = Field(
         InfectionPresent.NONE_OF_THE_ABOVE,
-        description="What evidence documents infection as current, active, or being evaluated/treated now?",
+        description=(
+            "What evidence documents infection as current, active, or being evaluated/treated now? "
+            "CONFIRMED: Infection confirmed by laboratory test or imaging, infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to infection; "
+            "SUSPECTED: Infection is suspected, likely, cannot be ruled out, infection is a differential diagnosis or infectious test result is pending; "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
 
@@ -109,9 +151,15 @@ class InfectionMention(SpanAugmentedMention):
 # Infection (Viral)
 ###############################################################################
 class ViralInfectionPresent(StrEnum):
-    CONFIRMED = "Viral infection confirmed by laboratory test or imaging, viral infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to viral infection"
-    SUSPECTED = "Viral infection is suspected, likely, cannot be ruled out, viral infection is a differential diagnosis or viral test result is pending"
-    NONE_OF_THE_ABOVE = "None of the above"
+    """
+    CONFIRMED: Viral infection confirmed by laboratory test or imaging, viral infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to viral infection
+    SUSPECTED: Viral infection is suspected, likely, cannot be ruled out, viral infection is a differential diagnosis or viral test result is pending
+    NONE_OF_THE_ABOVE: None of the above
+    """
+
+    CONFIRMED = "CONFIRMED"
+    SUSPECTED = "SUSPECTED"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 class ViralInfectionMention(SpanAugmentedMention):
@@ -120,7 +168,12 @@ class ViralInfectionMention(SpanAugmentedMention):
     )
     viral_infection: ViralInfectionPresent = Field(
         ViralInfectionPresent.NONE_OF_THE_ABOVE,
-        description="What evidence documents viral infection as current, active, or being evaluated/treated now?",
+        description=(
+            "What evidence documents viral infection as current, active, or being evaluated/treated now? "
+            "CONFIRMED: Viral infection confirmed by laboratory test or imaging, viral infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to viral infection; "
+            "SUSPECTED: Viral infection is suspected, likely, cannot be ruled out, viral infection is a differential diagnosis or viral test result is pending; "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
 
@@ -128,9 +181,15 @@ class ViralInfectionMention(SpanAugmentedMention):
 # Infection (Bacterial)
 ###############################################################################
 class BacterialInfectionPresent(StrEnum):
-    CONFIRMED = "Bacterial infection confirmed by laboratory test or imaging, bacterial infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to bacterial infection"
-    SUSPECTED = "Bacterial infection is suspected, likely, cannot be ruled out, bacterial infection is a differential diagnosis or bacterial test result is pending"
-    NONE_OF_THE_ABOVE = "None of the above"
+    """
+    CONFIRMED: Bacterial infection confirmed by laboratory test or imaging, bacterial infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to bacterial infection
+    SUSPECTED: Bacterial infection is suspected, likely, cannot be ruled out, bacterial infection is a differential diagnosis or bacterial test result is pending
+    NONE_OF_THE_ABOVE: None of the above
+    """
+
+    CONFIRMED = "CONFIRMED"
+    SUSPECTED = "SUSPECTED"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 class BacterialInfectionMention(SpanAugmentedMention):
@@ -139,7 +198,12 @@ class BacterialInfectionMention(SpanAugmentedMention):
     )
     bacterial_infection: BacterialInfectionPresent = Field(
         BacterialInfectionPresent.NONE_OF_THE_ABOVE,
-        description="What evidence documents bacterial infection as current, active, or being evaluated/treated now?",
+        description=(
+            "What evidence documents bacterial infection as current, active, or being evaluated/treated now? "
+            "CONFIRMED: Bacterial infection confirmed by laboratory test or imaging, bacterial infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to bacterial infection; "
+            "SUSPECTED: Bacterial infection is suspected, likely, cannot be ruled out, bacterial infection is a differential diagnosis or bacterial test result is pending; "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
 
@@ -147,9 +211,15 @@ class BacterialInfectionMention(SpanAugmentedMention):
 # Infection (Fungal)
 ###############################################################################
 class FungalInfectionPresent(StrEnum):
-    CONFIRMED = "Fungal infection confirmed by laboratory test or imaging, fungal infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to fungal infection"
-    SUSPECTED = "Fungal infection is suspected, likely, cannot be ruled out, fungal infection is a differential diagnosis or fungal test result is pending"
-    NONE_OF_THE_ABOVE = "None of the above"
+    """
+    CONFIRMED: Fungal infection confirmed by laboratory test or imaging, fungal infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to fungal infection
+    SUSPECTED: Fungal infection is suspected, likely, cannot be ruled out, fungal infection is a differential diagnosis or fungal test result is pending
+    NONE_OF_THE_ABOVE: None of the above
+    """
+
+    CONFIRMED = "CONFIRMED"
+    SUSPECTED = "SUSPECTED"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 class FungalInfectionMention(SpanAugmentedMention):
@@ -158,7 +228,12 @@ class FungalInfectionMention(SpanAugmentedMention):
     )
     fungal_infection: FungalInfectionPresent = Field(
         FungalInfectionPresent.NONE_OF_THE_ABOVE,
-        description="What evidence documents fungal infection as current, active, or being evaluated/treated now?",
+        description=(
+            "What evidence documents fungal infection as current, active, or being evaluated/treated now? "
+            "CONFIRMED: Fungal infection confirmed by laboratory test or imaging, fungal infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to fungal infection; "
+            "SUSPECTED: Fungal infection is suspected, likely, cannot be ruled out, fungal infection is a differential diagnosis or fungal test result is pending; "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
 
@@ -176,15 +251,18 @@ class GraftRejectionPresent(StrEnum):
 
     IVIG and plasmapheresis (PLEX) during the post-transplant (post induction) phase DOES imply
     --> `GraftRejectionPresent` > SUSPECTED (and possibly CONFIRMED or BIOPSY_PROVEN)
-    --> DSAPresent >  SUSPECTED (and possibly CONFIRMED)
+    --> DSAPresent > SUSPECTED (and possibly CONFIRMED)
+
+    BIOPSY_PROVEN: Biopsy proven kidney graft rejection or pathology proven kidney graft rejection
+    CONFIRMED: Kidney graft rejection was 'diagnosed', 'confirmed' or 'positive'
+    SUSPECTED: Kidney graft rejection presumed, suspected, likely, cannot be ruled out, biopsy result pending, or treatment with IVIG/plasmapheresis
+    NONE_OF_THE_ABOVE: None of the above
     """
 
-    BIOPSY_PROVEN = (
-        "Biopsy proven kidney graft rejection or pathology proven kidney graft rejection"
-    )
-    CONFIRMED = "Kidney graft rejection was 'diagnosed', 'confirmed' or 'positive'"
-    SUSPECTED = "Kidney graft rejection presumed, suspected, likely, cannot be ruled out, biopsy result pending, or treatment with IVIG/plasmapheresis"
-    NONE_OF_THE_ABOVE = "None of the above"
+    BIOPSY_PROVEN = "BIOPSY_PROVEN"
+    CONFIRMED = "CONFIRMED"
+    SUSPECTED = "SUSPECTED"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 class GraftRejectionMention(SpanAugmentedMention):
@@ -193,7 +271,13 @@ class GraftRejectionMention(SpanAugmentedMention):
     )
     graft_rejection: GraftRejectionPresent = Field(
         GraftRejectionPresent.NONE_OF_THE_ABOVE,
-        description="What evidence documents kidney graft rejection as current, active, or being evaluated/treated now?",
+        description=(
+            "What evidence documents kidney graft rejection as current, active, or being evaluated/treated now? "
+            "BIOPSY_PROVEN: Biopsy proven kidney graft rejection or pathology proven kidney graft rejection; "
+            "CONFIRMED: Kidney graft rejection was 'diagnosed', 'confirmed' or 'positive'; "
+            "SUSPECTED: Kidney graft rejection presumed, suspected, likely, cannot be ruled out, biopsy result pending, or treatment with IVIG/plasmapheresis; "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
 
@@ -201,9 +285,15 @@ class GraftRejectionMention(SpanAugmentedMention):
 # Graft Failure
 ###############################################################################
 class GraftFailurePresent(StrEnum):
-    CONFIRMED = "Kidney graft has failed or kidney graft loss"
-    SUSPECTED = "Kidney graft failure presumed, suspected, likely, or cannot be ruled out"
-    NONE_OF_THE_ABOVE = "None of the above"
+    """
+    CONFIRMED: Kidney graft has failed or kidney graft loss
+    SUSPECTED: Kidney graft failure presumed, suspected, likely, or cannot be ruled out
+    NONE_OF_THE_ABOVE: None of the above
+    """
+
+    CONFIRMED = "CONFIRMED"
+    SUSPECTED = "SUSPECTED"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 class GraftFailureMention(SpanAugmentedMention):
@@ -212,7 +302,12 @@ class GraftFailureMention(SpanAugmentedMention):
     )
     graft_failure: GraftFailurePresent = Field(
         GraftFailurePresent.NONE_OF_THE_ABOVE,
-        description="What evidence documents kidney graft failure as current, active, or being evaluated/treated now?",
+        description=(
+            "What evidence documents kidney graft failure as current, active, or being evaluated/treated now? "
+            "CONFIRMED: Kidney graft has failed or kidney graft loss; "
+            "SUSPECTED: Kidney graft failure presumed, suspected, likely, or cannot be ruled out; "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
 
@@ -223,12 +318,17 @@ class PTLDPresent(StrEnum):
     """
     Notice: PTLD treatments may also be used in 'rescue' therapy (DSA/graft rejection) or other cancers.
     One notable difference from other cancers (such as skin cancer) is the absence of "surgical excision" (lymphoma).
+
+    BIOPSY_PROVEN: Biopsy proven or pathology proven PTLD
+    CONFIRMED: PTLD was 'diagnosed', 'confirmed' or 'positive' or viral positive lymphoma
+    SUSPECTED: PTLD presumed, suspected, likely, cannot be ruled out, PTLD biopsy result pending, or treatment with chemotherapy/radiation
+    NONE_OF_THE_ABOVE: None of the above
     """
 
-    BIOPSY_PROVEN = "Biopsy proven or pathology proven PTLD"
-    CONFIRMED = "PTLD was 'diagnosed', 'confirmed' or 'positive' or viral positive lymphoma"
-    SUSPECTED = "PTLD presumed, suspected, likely, cannot be ruled out, PTLD biopsy result pending, or treatment with chemotherapy/radiation"
-    NONE_OF_THE_ABOVE = "None of the above"
+    BIOPSY_PROVEN = "BIOPSY_PROVEN"
+    CONFIRMED = "CONFIRMED"
+    SUSPECTED = "SUSPECTED"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 class PTLDMention(SpanAugmentedMention):
@@ -238,7 +338,13 @@ class PTLDMention(SpanAugmentedMention):
     )
     ptld: PTLDPresent = Field(
         PTLDPresent.NONE_OF_THE_ABOVE,
-        description="What evidence documents post transplant lymphoproliferative disorder (PTLD) as current, active, or being evaluated/treated now?",
+        description=(
+            "What evidence documents post transplant lymphoproliferative disorder (PTLD) as current, active, or being evaluated/treated now? "
+            "BIOPSY_PROVEN: Biopsy proven or pathology proven PTLD; "
+            "CONFIRMED: PTLD was 'diagnosed', 'confirmed' or 'positive' or viral positive lymphoma; "
+            "SUSPECTED: PTLD presumed, suspected, likely, cannot be ruled out, PTLD biopsy result pending, or treatment with chemotherapy/radiation; "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
 
@@ -250,12 +356,17 @@ class CancerPresent(StrEnum):
     Notice: Cancer treatments may also be used in 'rescue' therapy (DSA/graft rejection).
     PTLD is a type of cancer. PTLD is a lymphoma and thus not treated with "surgical excision".
     Skin cancer (of which there are many types carcinoma and melanoma) is treated with surgical excision.
+
+    BIOPSY_PROVEN: Biopsy proven or pathology proven cancer
+    CONFIRMED: Cancer was 'diagnosed', 'confirmed' or 'positive'
+    SUSPECTED: Cancer is presumed, suspected, likely, cannot be ruled out, biopsy of any lesion, or treatment with chemotherapy/radiation
+    NONE_OF_THE_ABOVE: None of the above
     """
 
-    BIOPSY_PROVEN = "Biopsy proven or pathology proven cancer"
-    CONFIRMED = "Cancer was 'diagnosed', 'confirmed' or 'positive'"
-    SUSPECTED = "Cancer is presumed, suspected, likely, cannot be ruled out, biopsy of any lesion, or treatment with chemotherapy/radiation"
-    NONE_OF_THE_ABOVE = "None of the above"
+    BIOPSY_PROVEN = "BIOPSY_PROVEN"
+    CONFIRMED = "CONFIRMED"
+    SUSPECTED = "SUSPECTED"
+    NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
 
 
 class CancerMention(SpanAugmentedMention):
@@ -264,7 +375,13 @@ class CancerMention(SpanAugmentedMention):
     )
     cancer: CancerPresent = Field(
         CancerPresent.NONE_OF_THE_ABOVE,
-        description="What evidence documents cancer as current, active, or being evaluated/treated now?",
+        description=(
+            "What evidence documents cancer as current, active, or being evaluated/treated now? "
+            "BIOPSY_PROVEN: Biopsy proven or pathology proven cancer; "
+            "CONFIRMED: Cancer was 'diagnosed', 'confirmed' or 'positive'; "
+            "SUSPECTED: Cancer is presumed, suspected, likely, cannot be ruled out, biopsy of any lesion, or treatment with chemotherapy/radiation; "
+            "NONE_OF_THE_ABOVE: None of the above"
+        ),
     )
 
 
@@ -320,10 +437,3 @@ class KidneyTransplantLongitudinalAnnotation(BaseModel):
     ptld_mention: PTLDMention
     cancer_mention: CancerMention
     deceased_mention: DeceasedMention
-
-
-if __name__ == "__main__":
-    basedir = os.path.dirname(__file__)
-
-    with open(f"{basedir}/schemas/irae_outcomes.json", "w", encoding="utf8") as f:
-        json.dump(KidneyTransplantLongitudinalAnnotation.model_json_schema(), f, indent=2)

--- a/cumulus_library_kidney_transplant/llm/model/outcome.py
+++ b/cumulus_library_kidney_transplant/llm/model/outcome.py
@@ -1,5 +1,3 @@
-import json
-import os
 from enum import StrEnum
 
 from pydantic import BaseModel, Field

--- a/cumulus_library_kidney_transplant/llm/model/outcome.py
+++ b/cumulus_library_kidney_transplant/llm/model/outcome.py
@@ -10,14 +10,12 @@ from cumulus_library_kidney_transplant.llm.model.base import SpanAugmentedMentio
 ###############################################################################
 # Therapeutic Status Compliance
 ###############################################################################
-class RxTherapeuticStatus(StrEnum):
-    """
-    THERAPEUTIC: Immunosuppression levels are documented as therapeutic, adequate, or within target range.
-    SUB_THERAPEUTIC: Immunosuppression levels are documented as subtherapeutic, insufficient, or below target range.
-    SUPRA_THERAPEUTIC: Immunosuppression levels are documented as supratherapeutic, above therapeutic level, or above target range.
-    NONE_OF_THE_ABOVE: None of the above
-    """
 
+# THERAPEUTIC: Immunosuppression levels are documented as therapeutic, adequate, or within target range.
+# SUB_THERAPEUTIC: Immunosuppression levels are documented as subtherapeutic, insufficient, or below target range.
+# SUPRA_THERAPEUTIC: Immunosuppression levels are documented as supratherapeutic, above therapeutic level, or above target range.
+# NONE_OF_THE_ABOVE: None of the above
+class RxTherapeuticStatus(StrEnum):
     THERAPEUTIC = "THERAPEUTIC"
     SUB_THERAPEUTIC = "SUB_THERAPEUTIC"
     SUPRA_THERAPEUTIC = "SUPRA_THERAPEUTIC"
@@ -40,14 +38,12 @@ class RxTherapeuticStatusMention(SpanAugmentedMention):
 ###############################################################################
 # Medication Compliance
 ###############################################################################
-class RxCompliance(StrEnum):
-    """
-    COMPLIANT: Patient is documented as compliant with immunosuppressive medications.
-    PARTIALLY_COMPLIANT: Patient is documented as only partially compliant with immunosuppressive medications.
-    NON_COMPLIANT: Patient is documented as noncompliant with immunosuppressive medications.
-    NONE_OF_THE_ABOVE: None of the above
-    """
 
+# COMPLIANT: Patient is documented as compliant with immunosuppressive medications.
+# PARTIALLY_COMPLIANT: Patient is documented as only partially compliant with immunosuppressive medications.
+# NON_COMPLIANT: Patient is documented as noncompliant with immunosuppressive medications.
+# NONE_OF_THE_ABOVE: None of the above
+class RxCompliance(StrEnum):
     COMPLIANT = "COMPLIANT"
     PARTIALLY_COMPLIANT = "PARTIALLY_COMPLIANT"
     NON_COMPLIANT = "NON_COMPLIANT"
@@ -76,6 +72,10 @@ class RxComplianceMention(SpanAugmentedMention):
 ###############################################################################
 # DSA Donor Specific Antibody
 ###############################################################################
+
+# CONFIRMED: DSA diagnostic test positive, DSA diagnosis 'confirmed' or 'positive', or increase in immunosuppression due to DSA
+# SUSPECTED: DSA suspected, DSA likely, DSA cannot be ruled out, DSA test result pending, or treatment with IVIG/plasmapheresis
+# NONE_OF_THE_ABOVE: None of the above
 class DSAPresent(StrEnum):
     """
     Notice: DSA is strongly related to `GraftRejectionPresent`.
@@ -88,10 +88,6 @@ class DSAPresent(StrEnum):
     IVIG and plasmapheresis (PLEX) during the post-transplant (post induction) phase DOES imply
     --> DSAPresent > SUSPECTED (and possibly CONFIRMED)
     --> `GraftRejectionPresent` > SUSPECTED (and possibly CONFIRMED or BIOPSY_PROVEN)
-
-    CONFIRMED: DSA diagnostic test positive, DSA diagnosis 'confirmed' or 'positive', or increase in immunosuppression due to DSA
-    SUSPECTED: DSA suspected, DSA likely, DSA cannot be ruled out, DSA test result pending, or treatment with IVIG/plasmapheresis
-    NONE_OF_THE_ABOVE: None of the above
     """
 
     CONFIRMED = "CONFIRMED"
@@ -120,13 +116,11 @@ class DSAMention(SpanAugmentedMention):
 #   * necessary for PNA and UTI infections that often do not have a confirmed infection type!
 #   * useful as a secondary check to ensure more specific infection types are not missed
 ############################################################################################################
-class InfectionPresent(StrEnum):
-    """
-    CONFIRMED: Infection confirmed by laboratory test or imaging, infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to infection
-    SUSPECTED: Infection is suspected, likely, cannot be ruled out, infection is a differential diagnosis or infectious test result is pending
-    NONE_OF_THE_ABOVE: None of the above
-    """
 
+# CONFIRMED: Infection confirmed by laboratory test or imaging, infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to infection
+# SUSPECTED: Infection is suspected, likely, cannot be ruled out, infection is a differential diagnosis or infectious test result is pending
+# NONE_OF_THE_ABOVE: None of the above
+class InfectionPresent(StrEnum):
     CONFIRMED = "CONFIRMED"
     SUSPECTED = "SUSPECTED"
     NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
@@ -150,13 +144,11 @@ class InfectionMention(SpanAugmentedMention):
 ###############################################################################
 # Infection (Viral)
 ###############################################################################
-class ViralInfectionPresent(StrEnum):
-    """
-    CONFIRMED: Viral infection confirmed by laboratory test or imaging, viral infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to viral infection
-    SUSPECTED: Viral infection is suspected, likely, cannot be ruled out, viral infection is a differential diagnosis or viral test result is pending
-    NONE_OF_THE_ABOVE: None of the above
-    """
 
+# CONFIRMED: Viral infection confirmed by laboratory test or imaging, viral infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to viral infection
+# SUSPECTED: Viral infection is suspected, likely, cannot be ruled out, viral infection is a differential diagnosis or viral test result is pending
+# NONE_OF_THE_ABOVE: None of the above
+class ViralInfectionPresent(StrEnum):
     CONFIRMED = "CONFIRMED"
     SUSPECTED = "SUSPECTED"
     NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
@@ -180,13 +172,11 @@ class ViralInfectionMention(SpanAugmentedMention):
 ###############################################################################
 # Infection (Bacterial)
 ###############################################################################
-class BacterialInfectionPresent(StrEnum):
-    """
-    CONFIRMED: Bacterial infection confirmed by laboratory test or imaging, bacterial infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to bacterial infection
-    SUSPECTED: Bacterial infection is suspected, likely, cannot be ruled out, bacterial infection is a differential diagnosis or bacterial test result is pending
-    NONE_OF_THE_ABOVE: None of the above
-    """
 
+# CONFIRMED: Bacterial infection confirmed by laboratory test or imaging, bacterial infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to bacterial infection
+# SUSPECTED: Bacterial infection is suspected, likely, cannot be ruled out, bacterial infection is a differential diagnosis or bacterial test result is pending
+# NONE_OF_THE_ABOVE: None of the above
+class BacterialInfectionPresent(StrEnum):
     CONFIRMED = "CONFIRMED"
     SUSPECTED = "SUSPECTED"
     NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
@@ -210,13 +200,11 @@ class BacterialInfectionMention(SpanAugmentedMention):
 ###############################################################################
 # Infection (Fungal)
 ###############################################################################
-class FungalInfectionPresent(StrEnum):
-    """
-    CONFIRMED: Fungal infection confirmed by laboratory test or imaging, fungal infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to fungal infection
-    SUSPECTED: Fungal infection is suspected, likely, cannot be ruled out, fungal infection is a differential diagnosis or fungal test result is pending
-    NONE_OF_THE_ABOVE: None of the above
-    """
 
+# CONFIRMED: Fungal infection confirmed by laboratory test or imaging, fungal infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to fungal infection
+# SUSPECTED: Fungal infection is suspected, likely, cannot be ruled out, fungal infection is a differential diagnosis or fungal test result is pending
+# NONE_OF_THE_ABOVE: None of the above
+class FungalInfectionPresent(StrEnum):
     CONFIRMED = "CONFIRMED"
     SUSPECTED = "SUSPECTED"
     NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
@@ -240,6 +228,11 @@ class FungalInfectionMention(SpanAugmentedMention):
 ###############################################################################
 # Graft Rejection
 ###############################################################################
+
+# BIOPSY_PROVEN: Biopsy proven kidney graft rejection or pathology proven kidney graft rejection
+# CONFIRMED: Kidney graft rejection was 'diagnosed', 'confirmed' or 'positive'
+# SUSPECTED: Kidney graft rejection presumed, suspected, likely, cannot be ruled out, biopsy result pending, or treatment with IVIG/plasmapheresis
+# NONE_OF_THE_ABOVE: None of the above
 class GraftRejectionPresent(StrEnum):
     """
     Notice: Graft rejection is strongly related to `DSAPresent`.
@@ -252,11 +245,6 @@ class GraftRejectionPresent(StrEnum):
     IVIG and plasmapheresis (PLEX) during the post-transplant (post induction) phase DOES imply
     --> `GraftRejectionPresent` > SUSPECTED (and possibly CONFIRMED or BIOPSY_PROVEN)
     --> DSAPresent > SUSPECTED (and possibly CONFIRMED)
-
-    BIOPSY_PROVEN: Biopsy proven kidney graft rejection or pathology proven kidney graft rejection
-    CONFIRMED: Kidney graft rejection was 'diagnosed', 'confirmed' or 'positive'
-    SUSPECTED: Kidney graft rejection presumed, suspected, likely, cannot be ruled out, biopsy result pending, or treatment with IVIG/plasmapheresis
-    NONE_OF_THE_ABOVE: None of the above
     """
 
     BIOPSY_PROVEN = "BIOPSY_PROVEN"
@@ -284,13 +272,11 @@ class GraftRejectionMention(SpanAugmentedMention):
 ###############################################################################
 # Graft Failure
 ###############################################################################
-class GraftFailurePresent(StrEnum):
-    """
-    CONFIRMED: Kidney graft has failed or kidney graft loss
-    SUSPECTED: Kidney graft failure presumed, suspected, likely, or cannot be ruled out
-    NONE_OF_THE_ABOVE: None of the above
-    """
 
+# CONFIRMED: Kidney graft has failed or kidney graft loss
+# SUSPECTED: Kidney graft failure presumed, suspected, likely, or cannot be ruled out
+# NONE_OF_THE_ABOVE: None of the above
+class GraftFailurePresent(StrEnum):
     CONFIRMED = "CONFIRMED"
     SUSPECTED = "SUSPECTED"
     NONE_OF_THE_ABOVE = "NONE_OF_THE_ABOVE"
@@ -314,15 +300,15 @@ class GraftFailureMention(SpanAugmentedMention):
 ###############################################################################
 # PTLD
 ###############################################################################
+
+# BIOPSY_PROVEN: Biopsy proven or pathology proven PTLD
+# CONFIRMED: PTLD was 'diagnosed', 'confirmed' or 'positive' or viral positive lymphoma
+# SUSPECTED: PTLD presumed, suspected, likely, cannot be ruled out, PTLD biopsy result pending, or treatment with chemotherapy/radiation
+# NONE_OF_THE_ABOVE: None of the above
 class PTLDPresent(StrEnum):
     """
     Notice: PTLD treatments may also be used in 'rescue' therapy (DSA/graft rejection) or other cancers.
     One notable difference from other cancers (such as skin cancer) is the absence of "surgical excision" (lymphoma).
-
-    BIOPSY_PROVEN: Biopsy proven or pathology proven PTLD
-    CONFIRMED: PTLD was 'diagnosed', 'confirmed' or 'positive' or viral positive lymphoma
-    SUSPECTED: PTLD presumed, suspected, likely, cannot be ruled out, PTLD biopsy result pending, or treatment with chemotherapy/radiation
-    NONE_OF_THE_ABOVE: None of the above
     """
 
     BIOPSY_PROVEN = "BIOPSY_PROVEN"
@@ -351,16 +337,16 @@ class PTLDMention(SpanAugmentedMention):
 ###############################################################################
 # Cancer
 ###############################################################################
+
+# BIOPSY_PROVEN: Biopsy proven or pathology proven cancer
+# CONFIRMED: Cancer was 'diagnosed', 'confirmed' or 'positive'
+# SUSPECTED: Cancer is presumed, suspected, likely, cannot be ruled out, biopsy of any lesion, or treatment with chemotherapy/radiation
+# NONE_OF_THE_ABOVE: None of the above
 class CancerPresent(StrEnum):
     """
     Notice: Cancer treatments may also be used in 'rescue' therapy (DSA/graft rejection).
     PTLD is a type of cancer. PTLD is a lymphoma and thus not treated with "surgical excision".
     Skin cancer (of which there are many types carcinoma and melanoma) is treated with surgical excision.
-
-    BIOPSY_PROVEN: Biopsy proven or pathology proven cancer
-    CONFIRMED: Cancer was 'diagnosed', 'confirmed' or 'positive'
-    SUSPECTED: Cancer is presumed, suspected, likely, cannot be ruled out, biopsy of any lesion, or treatment with chemotherapy/radiation
-    NONE_OF_THE_ABOVE: None of the above
     """
 
     BIOPSY_PROVEN = "BIOPSY_PROVEN"

--- a/cumulus_library_kidney_transplant/llm/model/transplant_history.py
+++ b/cumulus_library_kidney_transplant/llm/model/transplant_history.py
@@ -1,5 +1,3 @@
-import json 
-import os
 from pydantic import BaseModel, Field
 
 from cumulus_library_kidney_transplant.llm.model.base import SpanAugmentedMention

--- a/cumulus_library_kidney_transplant/llm/model/transplant_history.py
+++ b/cumulus_library_kidney_transplant/llm/model/transplant_history.py
@@ -41,9 +41,3 @@ class MultipleTransplantHistoryAnnotation(BaseModel):
 
     multiple_transplant_history_mention: MultipleTransplantHistoryMention
 
-
-if __name__ == "__main__":
-    basedir = os.path.dirname(__file__)
-
-    with open(f"{basedir}/schemas/irae_multiple_transplant_history.json", "w", encoding="utf8") as f:
-        json.dump(MultipleTransplantHistoryAnnotation.model_json_schema(), f, indent=2)

--- a/cumulus_library_kidney_transplant/llm/schemas/irae_donor.json
+++ b/cumulus_library_kidney_transplant/llm/schemas/irae_donor.json
@@ -1,11 +1,12 @@
 {
   "$defs": {
     "DonorHlaMatchQuality": {
+      "description": "WELL: Well matched (0-1 mismatches) OR recipient explicitly documented as not sensitized\nMODERATE: Moderately matched (2-4 mismatches) OR recipient explicitly documented as sensitized\nPOOR: Poorly matched (5-6 mismatches) OR recipient explicitly documented as highly sensitized\nNOT_MENTIONED: HLA match quality not mentioned",
       "enum": [
-        "Well matched (0-1 mismatches) OR recipient explicitly documented as not sensitized",
-        "Moderately matched (2-4 mismatches) OR recipient explicitly documented as sensitized",
-        "Poorly matched (5-6 mismatches) OR recipient explicitly documented as highly sensitized",
-        "HLA match quality not mentioned"
+        "WELL",
+        "MODERATE",
+        "POOR",
+        "NOT_MENTIONED"
       ],
       "title": "DonorHlaMatchQuality",
       "type": "string"
@@ -29,23 +30,24 @@
         },
         "donor_hla_match_quality": {
           "$ref": "#/$defs/DonorHlaMatchQuality",
-          "default": "HLA match quality not mentioned",
-          "description": "What was the HLA match quality for the first renal transplant?"
+          "default": "NOT_MENTIONED",
+          "description": "What was the HLA match quality for the first renal transplant? WELL: Well matched (0-1 mismatches) OR recipient explicitly documented as not sensitized; MODERATE: Moderately matched (2-4 mismatches) OR recipient explicitly documented as sensitized; POOR: Poorly matched (5-6 mismatches) OR recipient explicitly documented as highly sensitized; NOT_MENTIONED: HLA match quality not mentioned"
         }
       },
       "title": "DonorHlaMatchQualityMention",
       "type": "object"
     },
     "DonorHlaMismatchCount": {
+      "description": "Number of HLA mismatches between donor and recipient.\n\nZERO: 0 mismatches\nONE: 1 mismatch\nTWO: 2 mismatches\nTHREE: 3 mismatches\nFOUR: 4 mismatches\nFIVE: 5 mismatches\nSIX: 6 mismatches\nNOT_MENTIONED: HLA mismatch count not mentioned",
       "enum": [
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "HLA mismatch count not mentioned"
+        "ZERO",
+        "ONE",
+        "TWO",
+        "THREE",
+        "FOUR",
+        "FIVE",
+        "SIX",
+        "NOT_MENTIONED"
       ],
       "title": "DonorHlaMismatchCount",
       "type": "string"
@@ -69,18 +71,19 @@
         },
         "donor_hla_mismatch_count": {
           "$ref": "#/$defs/DonorHlaMismatchCount",
-          "default": "HLA mismatch count not mentioned",
-          "description": "What was the donor-recipient HLA mismatch count for the first renal transplant?"
+          "default": "NOT_MENTIONED",
+          "description": "What was the donor-recipient HLA mismatch count for the first renal transplant? ZERO: 0 mismatches; ONE: 1 mismatch; TWO: 2 mismatches; THREE: 3 mismatches; FOUR: 4 mismatches; FIVE: 5 mismatches; SIX: 6 mismatches; NOT_MENTIONED: HLA mismatch count not mentioned"
         }
       },
       "title": "DonorHlaMismatchCountMention",
       "type": "object"
     },
     "DonorRelationship": {
+      "description": "RELATED: Donor was biologically related to the renal transplant recipient\nUNRELATED: Donor was biologically unrelated to the renal transplant recipient\nNOT_MENTIONED: Donor relationship status was not mentioned",
       "enum": [
-        "Donor was biologically related to the renal transplant recipient",
-        "Donor was biologically unrelated to the renal transplant recipient",
-        "Donor relationship status was not mentioned"
+        "RELATED",
+        "UNRELATED",
+        "NOT_MENTIONED"
       ],
       "title": "DonorRelationship",
       "type": "string"
@@ -104,8 +107,8 @@
         },
         "donor_relationship": {
           "$ref": "#/$defs/DonorRelationship",
-          "default": "Donor relationship status was not mentioned",
-          "description": "Was the first renal transplant donor biologically related to the recipient?"
+          "default": "NOT_MENTIONED",
+          "description": "Was the first renal transplant donor biologically related to the recipient? RELATED: Donor was biologically related to the renal transplant recipient; UNRELATED: Donor was biologically unrelated to the renal transplant recipient; NOT_MENTIONED: Donor relationship status was not mentioned"
         }
       },
       "title": "DonorRelationshipMention",
@@ -146,10 +149,11 @@
       "type": "object"
     },
     "DonorType": {
+      "description": "LIVING: Donor was alive at time of renal transplant\nDECEASED: Donor was deceased at time of renal transplant\nNOT_MENTIONED: Donor was not mentioned as living or deceased",
       "enum": [
-        "Donor was alive at time of renal transplant",
-        "Donor was deceased at time of renal transplant",
-        "Donor was not mentioned as living or deceased"
+        "LIVING",
+        "DECEASED",
+        "NOT_MENTIONED"
       ],
       "title": "DonorType",
       "type": "string"
@@ -173,8 +177,8 @@
         },
         "donor_type": {
           "$ref": "#/$defs/DonorType",
-          "default": "Donor was not mentioned as living or deceased",
-          "description": "Was the first renal donor living at the time of renal transplant?"
+          "default": "NOT_MENTIONED",
+          "description": "Was the first renal donor living at the time of renal transplant? LIVING: Donor was alive at time of renal transplant; DECEASED: Donor was deceased at time of renal transplant; NOT_MENTIONED: Donor was not mentioned as living or deceased"
         }
       },
       "title": "DonorTypeMention",

--- a/cumulus_library_kidney_transplant/llm/schemas/irae_donor.json
+++ b/cumulus_library_kidney_transplant/llm/schemas/irae_donor.json
@@ -1,7 +1,6 @@
 {
   "$defs": {
     "DonorHlaMatchQuality": {
-      "description": "WELL: Well matched (0-1 mismatches) OR recipient explicitly documented as not sensitized\nMODERATE: Moderately matched (2-4 mismatches) OR recipient explicitly documented as sensitized\nPOOR: Poorly matched (5-6 mismatches) OR recipient explicitly documented as highly sensitized\nNOT_MENTIONED: HLA match quality not mentioned",
       "enum": [
         "WELL",
         "MODERATE",
@@ -15,13 +14,12 @@
       "description": "Human leukocyte antigen (HLA) match quality of the first renal transplant. If there is only one\ntransplant mentioned, assume that this is the first transplant.",
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -34,11 +32,15 @@
           "description": "What was the HLA match quality for the first renal transplant? WELL: Well matched (0-1 mismatches) OR recipient explicitly documented as not sensitized; MODERATE: Moderately matched (2-4 mismatches) OR recipient explicitly documented as sensitized; POOR: Poorly matched (5-6 mismatches) OR recipient explicitly documented as highly sensitized; NOT_MENTIONED: HLA match quality not mentioned"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "DonorHlaMatchQualityMention",
       "type": "object"
     },
     "DonorHlaMismatchCount": {
-      "description": "Number of HLA mismatches between donor and recipient.\n\nZERO: 0 mismatches\nONE: 1 mismatch\nTWO: 2 mismatches\nTHREE: 3 mismatches\nFOUR: 4 mismatches\nFIVE: 5 mismatches\nSIX: 6 mismatches\nNOT_MENTIONED: HLA mismatch count not mentioned",
+      "description": "Number of HLA mismatches between donor and recipient.",
       "enum": [
         "ZERO",
         "ONE",
@@ -56,13 +58,12 @@
       "description": "Human leukocyte antigen (HLA) mismatch count for the first renal transplant. If there is only\none transplant mentioned, assume that this is the first transplant.",
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -75,11 +76,14 @@
           "description": "What was the donor-recipient HLA mismatch count for the first renal transplant? ZERO: 0 mismatches; ONE: 1 mismatch; TWO: 2 mismatches; THREE: 3 mismatches; FOUR: 4 mismatches; FIVE: 5 mismatches; SIX: 6 mismatches; NOT_MENTIONED: HLA mismatch count not mentioned"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "DonorHlaMismatchCountMention",
       "type": "object"
     },
     "DonorRelationship": {
-      "description": "RELATED: Donor was biologically related to the renal transplant recipient\nUNRELATED: Donor was biologically unrelated to the renal transplant recipient\nNOT_MENTIONED: Donor relationship status was not mentioned",
       "enum": [
         "RELATED",
         "UNRELATED",
@@ -92,13 +96,12 @@
       "description": "Relatedness of the donor and recipient in the first renal transplant. If there is only one\ntransplant mentioned, assume that this is the first transplant. Exclude donors that are only\nhypothetical or under evaluation/assessment.",
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -111,6 +114,10 @@
           "description": "Was the first renal transplant donor biologically related to the recipient? RELATED: Donor was biologically related to the renal transplant recipient; UNRELATED: Donor was biologically unrelated to the renal transplant recipient; NOT_MENTIONED: Donor relationship status was not mentioned"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "DonorRelationshipMention",
       "type": "object"
     },
@@ -118,13 +125,12 @@
       "description": "Date of the first renal transplant. If there is only one transplant mentioned,\nassume that this is the first transplant. If a POD (post-operative day) is mentioned,\nuse that to infer the date.",
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -145,11 +151,14 @@
           "title": "Donor Transplant Date"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "DonorTransplantDateMention",
       "type": "object"
     },
     "DonorType": {
-      "description": "LIVING: Donor was alive at time of renal transplant\nDECEASED: Donor was deceased at time of renal transplant\nNOT_MENTIONED: Donor was not mentioned as living or deceased",
       "enum": [
         "LIVING",
         "DECEASED",
@@ -162,13 +171,12 @@
       "description": "Type of donor in the first renal transplant. If there is only one transplant\nmentioned, assume that this is the first transplant. Exclude donors that are only\nhypothetical or under evaluation/assessment.",
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -181,11 +189,15 @@
           "description": "Was the first renal donor living at the time of renal transplant? LIVING: Donor was alive at time of renal transplant; DECEASED: Donor was deceased at time of renal transplant; NOT_MENTIONED: Donor was not mentioned as living or deceased"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "DonorTypeMention",
       "type": "object"
     },
     "Serostatus": {
-      "description": "Serostatus classification based on IgG serology or explicit seropositive/seronegative statements.\n- SEROPOSITIVE: Documented IgG positive / seropositive\n- SERONEGATIVE: Documented IgG negative / seronegative\n- NOT_MENTIONED: No serostatus documentation found",
+      "description": "Serostatus classification based on IgG serology or explicit seropositive/seronegative statements.",
       "enum": [
         "SEROPOSITIVE",
         "SERONEGATIVE",
@@ -198,13 +210,12 @@
       "description": "CMV serostatus of the donor at the time of first renal transplant.",
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -214,9 +225,13 @@
         "serostatus": {
           "$ref": "#/$defs/Serostatus",
           "default": "NOT_MENTIONED",
-          "description": "CMV serostatus of the renal donor. Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. Look for patterns like 'CMV D+', 'CMV D-', 'donor CMV IgG positive', 'donor CMV IgG negative', etc."
+          "description": "CMV serostatus of the renal donor. Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. SEROPOSITIVE: Documented IgG positive / seropositiveSERONEGATIVE: Documented IgG negative / seronegativeNOT_MENTIONED: No serostatus documentation foundLook for patterns like 'CMV D+', 'CMV D-', 'donor CMV IgG positive', 'donor CMV IgG negative', etc."
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "SerostatusDonorCMVMention",
       "type": "object"
     },
@@ -224,13 +239,12 @@
       "description": "EBV serostatus of the donor at the time of first renal transplant.",
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -240,9 +254,13 @@
         "serostatus": {
           "$ref": "#/$defs/Serostatus",
           "default": "NOT_MENTIONED",
-          "description": "EBV serostatus of the renal donor. Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. Look for patterns like 'EBV D+', 'EBV D-', 'donor EBV IgG positive', 'donor EBV IgG negative', etc."
+          "description": "EBV serostatus of the renal donor. Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. SEROPOSITIVE: Documented IgG positive / seropositiveSERONEGATIVE: Documented IgG negative / seronegativeNOT_MENTIONED: No serostatus documentation foundLook for patterns like 'EBV D+', 'EBV D-', 'donor EBV IgG positive', 'donor EBV IgG negative', etc."
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "SerostatusDonorEBVMention",
       "type": "object"
     },
@@ -250,13 +268,12 @@
       "description": "Overall serostatus of the donor at the time of first renal transplant.",
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -266,9 +283,13 @@
         "serostatus": {
           "$ref": "#/$defs/Serostatus",
           "default": "NOT_MENTIONED",
-          "description": "Overall serostatus of the renal donor for ANY virus. Set SEROPOSITIVE if the note documents the donor as seropositive for ANY virus (including CMV, EBV, HBV, HCV, HSV, VZV, or an unspecified virus), or uses generic language such as 'donor is seropositive' without naming the virus. Set SERONEGATIVE only if it explicitly states the donor was seronegative for all IgG tests. Otherwise use NOT_MENTIONED."
+          "description": "Overall serostatus of the renal donor for ANY virus. SEROPOSITIVE: Documented IgG positive / seropositiveSERONEGATIVE: Documented IgG negative / seronegativeNOT_MENTIONED: No serostatus documentation foundSet SEROPOSITIVE if the note documents the donor as seropositive for ANY virus (including CMV, EBV, HBV, HCV, HSV, VZV, or an unspecified virus), or uses generic language such as 'donor is seropositive' without naming the virus. Set SERONEGATIVE only if it explicitly states the donor was seronegative for all IgG tests. Otherwise use NOT_MENTIONED."
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "SerostatusDonorMention",
       "type": "object"
     },
@@ -276,13 +297,12 @@
       "description": "CMV serostatus of the recipient at the time of first renal transplant.",
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -292,9 +312,13 @@
         "serostatus": {
           "$ref": "#/$defs/Serostatus",
           "default": "NOT_MENTIONED",
-          "description": "CMV serostatus of the recipient at the time of renal transplant. Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. Look for patterns like 'CMV R+', 'CMV R-', 'recipient CMV IgG positive', 'recipient CMV IgG negative', etc."
+          "description": "CMV serostatus of the recipient at the time of renal transplant. SEROPOSITIVE: Documented IgG positive / seropositiveSERONEGATIVE: Documented IgG negative / seronegativeNOT_MENTIONED: No serostatus documentation foundChoose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. Look for patterns like 'CMV R+', 'CMV R-', 'recipient CMV IgG positive', 'recipient CMV IgG negative', etc."
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "SerostatusRecipientCMVMention",
       "type": "object"
     },
@@ -302,13 +326,12 @@
       "description": "EBV serostatus of the recipient at the time of first renal transplant.",
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -318,9 +341,13 @@
         "serostatus": {
           "$ref": "#/$defs/Serostatus",
           "default": "NOT_MENTIONED",
-          "description": "EBV serostatus of the recipient at the time of renal transplant. Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. Look for patterns like 'EBV R+', 'EBV R-', 'recipient EBV IgG positive', 'recipient EBV IgG negative', etc."
+          "description": "EBV serostatus of the recipient at the time of renal transplant. SEROPOSITIVE: Documented IgG positive / seropositiveSERONEGATIVE: Documented IgG negative / seronegativeNOT_MENTIONED: No serostatus documentation foundChoose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. Look for patterns like 'EBV R+', 'EBV R-', 'recipient EBV IgG positive', 'recipient EBV IgG negative', etc."
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "SerostatusRecipientEBVMention",
       "type": "object"
     },
@@ -328,13 +355,12 @@
       "description": "Overall serostatus of the recipient at the time of first renal transplant.",
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -344,9 +370,13 @@
         "serostatus": {
           "$ref": "#/$defs/Serostatus",
           "default": "NOT_MENTIONED",
-          "description": "Serostatus of the recipient at the time of renal transplant for ANY virus. Set SEROPOSITIVE if the note documents the recipient as seropositive for ANY virus (including CMV, EBV, HBV, HCV, HSV, VZV, or an unspecified virus), or if the text states 'recipient is seropositive' without naming the virus. Set SERONEGATIVE only if explicitly stated the recipient was seronegative. Otherwise use NOT_MENTIONED."
+          "description": "Serostatus of the recipient at the time of renal transplant for ANY virus. SEROPOSITIVE: Documented IgG positive / seropositiveSERONEGATIVE: Documented IgG negative / seronegativeNOT_MENTIONED: No serostatus documentation foundSet SEROPOSITIVE if the note documents the recipient as seropositive for ANY virus (including CMV, EBV, HBV, HCV, HSV, VZV, or an unspecified virus), or if the text states 'recipient is seropositive' without naming the virus. Set SERONEGATIVE only if explicitly stated the recipient was seronegative. Otherwise use NOT_MENTIONED."
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "SerostatusRecipientMention",
       "type": "object"
     }

--- a/cumulus_library_kidney_transplant/llm/schemas/irae_medications.json
+++ b/cumulus_library_kidney_transplant/llm/schemas/irae_medications.json
@@ -19,23 +19,23 @@
         },
         "status": {
           "$ref": "#/$defs/RxStatus",
-          "default": "None of the above",
-          "description": "What is the status of this medication?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "What is the status of this medication? ACTIVE: Medication order is active (currently prescribed and intended for ongoing use); INTENDED: Medication is planned/ordered/prescribed but therapy has not yet started; COMPLETED: Medication course is finished (all doses given or intended duration completed); STOPPED: Medication was stopped or permanently discontinued before completion; CANCELED: Medication order was canceled/withdrawn before any doses were administered; ON_HOLD: Medication is temporarily paused (on-hold, suspended, or interrupted); NONE_OF_THE_ABOVE: None of the above"
         },
         "category": {
           "$ref": "#/$defs/RxCategory",
-          "default": "None of the above",
-          "description": "In which healthcare setting is this medication prescribed/administered?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "In which healthcare setting is this medication prescribed/administered? INPATIENT: Medication ordered/administered during an inpatient/acute care setting; OUTPATIENT: Medication ordered/administered during an outpatient setting; COMMUNITY: Medication ordered/consumed by the patient in their home (including long term care, nursing homes, etc); NONE_OF_THE_ABOVE: None of the above"
         },
         "route": {
           "$ref": "#/$defs/RxRoute",
-          "default": "None of the above",
-          "description": "What is the the route of administration for this medication?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "What is the route of administration for this medication? PO: Oral (includes swallowed and sublingual routes); NG: Nasogastric/Feeding tube (NG/PEG); INJECTION: Injection (IV, SC, or IM); INHALATION: Inhalation (respiratory route); TOPICAL: Topical (skin or mucosal surface); NONE_OF_THE_ABOVE: None of the above"
         },
         "phase": {
           "$ref": "#/$defs/TreatmentPhase",
-          "default": "None of the above",
-          "description": "What is the treatment phase for this medication?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "What is the treatment phase for this medication? INDUCTION: Induction therapy; MAINTENANCE: Maintenance therapy; RESCUE: Rescue therapy; NONE_OF_THE_ABOVE: None of the above"
         },
         "expected_supply_days": {
           "anyOf": [
@@ -65,8 +65,8 @@
         },
         "frequency": {
           "$ref": "#/$defs/RxFrequency",
-          "default": "None of the above",
-          "description": "What is the frequency of this medication?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "What is the frequency of this medication? QD: once daily; BID: twice daily; TID: three times daily; QID: four times daily; QOD: every other day; Q6H: every 6 hours; Q8H: every 8 hours; Q12H: every 12 hours; WEEKLY: once weekly; Q2W: once every 2 weeks; Q4W: once every 4 weeks; MONTHLY: once monthly; OTHER: non-standard frequency (use timing_text); NONE_OF_THE_ABOVE: None of the above"
         },
         "start_date": {
           "anyOf": [
@@ -96,8 +96,8 @@
         },
         "quantity_unit": {
           "$ref": "#/$defs/RxQuantityUnit",
-          "default": "None of the above",
-          "description": "Medication prescribed unit"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "Medication prescribed unit. Mass: MG=mg, G=g, UG=ug (microgram), KG=kg; Volume: ML=mL, L=L; International Units: U=U, IU=[iU]; Countable: TABLET, CAPSULE, PUFF, PATCH, SUPPOSITORY; Ratios: MG_PER_ML, MG_PER_KG, U_PER_KG, UG_PER_KG_PER_MIN; Time: H=hours, MIN=minutes, D=days; NONE_OF_THE_ABOVE: None of the above"
         },
         "quantity_value": {
           "anyOf": [
@@ -114,47 +114,48 @@
         },
         "drug_class": {
           "$ref": "#/$defs/RxClassImmunosuppression",
-          "default": "None of the above",
-          "description": "Extract the Immunosuppressive drug class or therapy modality documented for this medication, if present"
+          "default": "NONE",
+          "description": "Extract the Immunosuppressive drug class or therapy modality documented for this medication, if present. ANTIMET: Anti-Metabolite (e.g., azathioprine, mycophenolate); CNI: Calcineurin Inhibitor (e.g., tacrolimus, cyclosporine); STEROID: Corticosteroid (e.g., prednisone, methylprednisolone); MTOR: mTOR Inhibitor (e.g., sirolimus, everolimus); COSTIM: Costimulation Blocker/blockade (e.g., belatacept); IVIG: Immunoglobulin (e.g., IVIG, Cytogam); POLYCLONAL: Polyclonal antibody (e.g., ATG, ALG); MONOCLONAL: Monoclonal antibody (e.g., basiliximab, rituximab); OTHER: Other immunosuppressive drug; NONE: None of the above"
         },
         "ingredient": {
           "$ref": "#/$defs/RxIngredientImmunosuppression",
-          "default": "None of the above",
-          "description": "Extract the specific immunosuppressive drug ingredient documented for this medication, if present"
+          "default": "NONE",
+          "description": "Extract the specific immunosuppressive drug ingredient documented for this medication, if present. ANTIMET group: AZA=Azathioprine, MMF=Mycophenolate Mofetil, ANTIMET_OTHER=other anti-metabolite; CNI group: CYA=Cyclosporine, TAC=Tacrolimus, CNI_OTHER=other calcineurin inhibitor; STEROID group: MEDROL=Methylprednisolone, PDL=Prednisolone, PRED=Prednisone, STEROID_OTHER=other corticosteroid; COSTIM group: BEL=Belatacept, ABA=Abatacept, COSTIM_OTHER=other costimulation blocker; IVIG group: IVIG=Intravenous Immunoglobulin, CYTOGAM=Cytogam (CMV-specific hyperimmune globulin), IVIG_OTHER=other immunoglobulin; MTOR group: EVE=Everolimus, SRL=Sirolimus, MTOR_OTHER=other mTOR inhibitor; MONOCLONAL group: ALEM=Alemtuzumab, BASI=Basiliximab, DAC=Daclizumab, RTX=Rituximab, MONOCLONAL_OTHER=other monoclonal antibody; POLYCLONAL group: ATG=Antithymocyte Globulin, POLYCLONAL_OTHER=other polyclonal antibody; NONE: None of the above"
         }
       },
       "title": "ImmunosuppressiveMedicationMention",
       "type": "object"
     },
     "RxCategory": {
-      "description": "https://build.fhir.org/valueset-medicationrequest-admin-location.html",
+      "description": "https://build.fhir.org/valueset-medicationrequest-admin-location.html\n\nINPATIENT: Medication ordered/administered during an inpatient/acute care setting\nOUTPATIENT: Medication ordered/administered during an outpatient setting\nCOMMUNITY: Medication ordered/consumed by the patient in their home (including long term care, nursing homes, etc)\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "Medication ordered/administered during an inpatient/acute care setting",
-        "Medication ordered/administered during an outpatient setting",
-        "Medication ordered/consumed by the patient in their home (including long term care, nursing homes, etc)",
-        "None of the above"
+        "INPATIENT",
+        "OUTPATIENT",
+        "COMMUNITY",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "RxCategory",
       "type": "string"
     },
     "RxClassImmunosuppression": {
-      "description": "RxClass Immunosuppression",
+      "description": "Immunosuppressive drug class or therapy modality.\n\nANTIMET: Anti-Metabolite (e.g., azathioprine, mycophenolate)\nCNI: Calcineurin Inhibitor (e.g., tacrolimus, cyclosporine)\nSTEROID: Corticosteroid (e.g., prednisone, methylprednisolone)\nMTOR: mTOR Inhibitor (e.g., sirolimus, everolimus)\nCOSTIM: Costimulation Blocker/blockade (e.g., belatacept)\nIVIG: Immunoglobulin (e.g., IVIG, Cytogam)\nPOLYCLONAL: Polyclonal antibody (e.g., ATG, ALG)\nMONOCLONAL: Monoclonal antibody (mAb, e.g., basiliximab, rituximab)\nOTHER: Other immunosuppressive drug\nNONE: None of the above",
       "enum": [
-        "Anti-Metabolite (ANTIMET)",
-        "Calcineurin Inhibitor (CNI)",
-        "Corticosteroid (CS)",
-        "mTOR Inhibitor (MTOR)",
-        "Costimulation Blocker/blockade (COSTIM)",
-        "Immunoglobulin (IVIG)",
-        "Polyclonal antibody (e.g., ATG, ALG)",
-        "Monoclonal antibody (mAb, e.g., basiliximab, rituximab)",
-        "Other immunosuppressive drug",
-        "None of the above"
+        "ANTIMET",
+        "CNI",
+        "STEROID",
+        "MTOR",
+        "COSTIM",
+        "IVIG",
+        "POLYCLONAL",
+        "MONOCLONAL",
+        "OTHER",
+        "NONE"
       ],
       "title": "RxClassImmunosuppression",
       "type": "string"
     },
     "RxFrequency": {
+      "description": "QD: once daily (1x/day)\nBID: twice daily (2x/day)\nTID: three times daily (3x/day)\nQID: four times daily (4x/day)\nQOD: every other day (1/2x/day)\nQ6H: every 6 hours (4x/day)\nQ8H: every 8 hours (3x/day)\nQ12H: every 12 hours (2x/day)\nWEEKLY: once every 7 days\nQ2W: once every 2 weeks (14 days)\nQ4W: once every 4 weeks (28 days)\nMONTHLY: once every 4 weeks (28 days)\nOTHER: use timing_text for non-standard frequency\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
         "QD",
         "BID",
@@ -169,106 +170,107 @@
         "Q4W",
         "MONTHLY",
         "OTHER",
-        "None of the above"
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "RxFrequency",
       "type": "string"
     },
     "RxIngredientImmunosuppression": {
-      "description": "The specific immunosuppressive drug ingredient",
+      "description": "The specific immunosuppressive drug ingredient.\n\nANTIMET group: AZA=Azathioprine, MMF=Mycophenolate Mofetil, ANTIMET_OTHER=Other anti-metabolite\nCNI group: CYA=Cyclosporine, TAC=Tacrolimus, CNI_OTHER=Other calcineurin inhibitor\nSTEROID group: MEDROL=Methylprednisolone, PDL=Prednisolone, PRED=Prednisone, STEROID_OTHER=Other corticosteroid\nCOSTIM group: BEL=Belatacept, ABA=Abatacept, COSTIM_OTHER=Other costimulation blocker\nIVIG group: IVIG=Intravenous Immunoglobulin, CYTOGAM=Cytogam (CMV-specific hyperimmune globulin), IVIG_OTHER=Other immunoglobulin\nMTOR group: EVE=Everolimus, SRL=Sirolimus, MTOR_OTHER=Other mTOR inhibitor\nMONOCLONAL group: ALEM=Alemtuzumab, BASI=Basiliximab, DAC=Daclizumab, RTX=Rituximab, MONOCLONAL_OTHER=Other monoclonal antibody\nPOLYCLONAL group: ATG=Antithymocyte Globulin, POLYCLONAL_OTHER=Other polyclonal antibody\nNONE: None of the above",
       "enum": [
-        "Azathioprine",
-        "Mycophenolate Mofetil",
-        "Other anti-metabolite ingredient",
-        "Cyclosporine",
-        "Tacrolimus",
-        "Other calcineurin inhibitor ingredient",
-        "Methylprednisolone",
-        "Prednisolone",
-        "Prednisone",
-        "Other corticosteroid ingredient",
-        "Belatacept",
-        "Abatacept",
-        "Other Costimulation blocker ingredient",
-        "Intravenous Immunoglobulin (IVIG)",
-        "Cytogam (CMV-specific hyperimmune globulin)",
-        "Other immunoglobulin therapy",
-        "Everolimus",
-        "Sirolimus",
-        "Other mTOR inhibitor ingredient",
-        "Alemtuzumab",
-        "Basiliximab",
-        "Daclizumab",
-        "Rituximab",
-        "Other Monoclonal antibody drug",
-        "Antithymocyte Globulin (ATG)",
-        "Other polyclonal antibodies ingredient",
-        "None of the above"
+        "AZA",
+        "MMF",
+        "ANTIMET_OTHER",
+        "CYA",
+        "TAC",
+        "CNI_OTHER",
+        "MEDROL",
+        "PDL",
+        "PRED",
+        "STEROID_OTHER",
+        "BEL",
+        "ABA",
+        "COSTIM_OTHER",
+        "IVIG",
+        "CYTOGAM",
+        "IVIG_OTHER",
+        "EVE",
+        "SRL",
+        "MTOR_OTHER",
+        "ALEM",
+        "BASI",
+        "DAC",
+        "RTX",
+        "MONOCLONAL_OTHER",
+        "ATG",
+        "POLYCLONAL_OTHER",
+        "NONE"
       ],
       "title": "RxIngredientImmunosuppression",
       "type": "string"
     },
     "RxQuantityUnit": {
+      "description": "UCUM unit codes for medication quantity.\n\nMass: MG=mg, G=g, UG=ug (microgram/mcg), KG=kg\nVolume: ML=mL, L=L\nInternational Units: U=U, IU=[iU]\nCountable: TABLET={tablet}, CAPSULE={capsule}, PUFF={puff}, PATCH={patch}, SUPPOSITORY={suppository}\nRatios: MG_PER_ML=mg/mL, MG_PER_KG=mg/kg, U_PER_KG=U/kg, UG_PER_KG_PER_MIN=ug/kg/min\nTime (infusion rates): H=h, MIN=min, D=d\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "mg",
-        "g",
-        "ug",
-        "kg",
-        "mL",
+        "MG",
+        "G",
+        "UG",
+        "KG",
+        "ML",
         "L",
         "U",
-        "[iU]",
-        "{tablet}",
-        "{capsule}",
-        "{puff}",
-        "{patch}",
-        "{suppository}",
-        "mg/mL",
-        "mg/kg",
-        "U/kg",
-        "ug/kg/min",
-        "h",
-        "min",
-        "d",
-        "None of the above"
+        "IU",
+        "TABLET",
+        "CAPSULE",
+        "PUFF",
+        "PATCH",
+        "SUPPOSITORY",
+        "MG_PER_ML",
+        "MG_PER_KG",
+        "U_PER_KG",
+        "UG_PER_KG_PER_MIN",
+        "H",
+        "MIN",
+        "D",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "RxQuantityUnit",
       "type": "string"
     },
     "RxRoute": {
-      "description": "Route of Administration can \"help\" (but not deterministic) for drug metadata, examples\n* Injection --> antibody for induction/rescue therapy\n* Topical --> skin lesions\n* Inhalation --> Steroid\nhttps://build.fhir.org/valueset-route-codes.html",
+      "description": "Route of Administration can \"help\" (but not deterministic) for drug metadata, examples\n* Injection --> antibody for induction/rescue therapy\n* Topical --> skin lesions\n* Inhalation --> Steroid\nhttps://build.fhir.org/valueset-route-codes.html\n\nPO: Oral (includes swallowed and sublingual routes)\nNG: Nasogastric/Feeding tube (NG/PEG)\nINJECTION: Injection (IV, SC, or IM)\nINHALATION: Inhalation (respiratory route)\nTOPICAL: Topical (skin or mucosal surface)\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "Oral (includes swallowed and sublingual routes)",
-        "Nasogastric/Feeding tube (NG/PEG)",
-        "Injection (IV, SC, or IM)",
-        "Inhalation (respiratory route)",
-        "Topical (skin or mucosal surface)",
-        "None of the above"
+        "PO",
+        "NG",
+        "INJECTION",
+        "INHALATION",
+        "TOPICAL",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "RxRoute",
       "type": "string"
     },
     "RxStatus": {
-      "description": "Medication Status (including Intent because chart review is NOT always identical to Med Request)\nhttps://build.fhir.org/valueset-medicationrequest-status.html\nhttps://build.fhir.org/valueset-medicationrequest-intent.html",
+      "description": "Medication Status (including Intent because chart review is NOT always identical to Med Request)\nhttps://build.fhir.org/valueset-medicationrequest-status.html\nhttps://build.fhir.org/valueset-medicationrequest-intent.html\n\nACTIVE: Medication order is active (currently prescribed and intended for ongoing use).\nINTENDED: Medication is planned/ordered/prescribed but therapy has not yet started.\nCOMPLETED: Medication course is finished (all doses given or intended duration completed).\nSTOPPED: Medication was stopped or permanently discontinued before completion.\nCANCELED: Medication order was canceled/withdrawn before any doses were administered.\nON_HOLD: Medication is temporarily paused (on-hold, suspended, or interrupted).\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "Medication order is active (currently prescribed and intended for ongoing use).",
-        "Medication is planned/ordered/prescribed but therapy has not yet started.",
-        "Medication course is finished (all doses given or intended duration completed).",
-        "Medication was stopped or permanently discontinued before completion.",
-        "Medication order was canceled/withdrawn before any doses were administered.",
-        "Medication is temporarily paused (on-hold, suspended, or interrupted).",
-        "None of the above"
+        "ACTIVE",
+        "INTENDED",
+        "COMPLETED",
+        "STOPPED",
+        "CANCELED",
+        "ON_HOLD",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "RxStatus",
       "type": "string"
     },
     "TreatmentPhase": {
-      "description": "Treatment Phase",
+      "description": "Treatment Phase\n\nINDUCTION: Induction therapy\nMAINTENANCE: Maintenance therapy\nRESCUE: Rescue therapy\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "Induction therapy",
-        "Maintenance therapy",
-        "Rescue therapy",
-        "None of the above"
+        "INDUCTION",
+        "MAINTENANCE",
+        "RESCUE",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "TreatmentPhase",
       "type": "string"

--- a/cumulus_library_kidney_transplant/llm/schemas/irae_medications.json
+++ b/cumulus_library_kidney_transplant/llm/schemas/irae_medications.json
@@ -4,13 +4,12 @@
       "description": "Mentions of ImmunosuppressiveMedications for this given chart.",
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -123,11 +122,15 @@
           "description": "Extract the specific immunosuppressive drug ingredient documented for this medication, if present. ANTIMET group: AZA=Azathioprine, MMF=Mycophenolate Mofetil, ANTIMET_OTHER=other anti-metabolite; CNI group: CYA=Cyclosporine, TAC=Tacrolimus, CNI_OTHER=other calcineurin inhibitor; STEROID group: MEDROL=Methylprednisolone, PDL=Prednisolone, PRED=Prednisone, STEROID_OTHER=other corticosteroid; COSTIM group: BEL=Belatacept, ABA=Abatacept, COSTIM_OTHER=other costimulation blocker; IVIG group: IVIG=Intravenous Immunoglobulin, CYTOGAM=Cytogam (CMV-specific hyperimmune globulin), IVIG_OTHER=other immunoglobulin; MTOR group: EVE=Everolimus, SRL=Sirolimus, MTOR_OTHER=other mTOR inhibitor; MONOCLONAL group: ALEM=Alemtuzumab, BASI=Basiliximab, DAC=Daclizumab, RTX=Rituximab, MONOCLONAL_OTHER=other monoclonal antibody; POLYCLONAL group: ATG=Antithymocyte Globulin, POLYCLONAL_OTHER=other polyclonal antibody; NONE: None of the above"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "ImmunosuppressiveMedicationMention",
       "type": "object"
     },
     "RxCategory": {
-      "description": "https://build.fhir.org/valueset-medicationrequest-admin-location.html\n\nINPATIENT: Medication ordered/administered during an inpatient/acute care setting\nOUTPATIENT: Medication ordered/administered during an outpatient setting\nCOMMUNITY: Medication ordered/consumed by the patient in their home (including long term care, nursing homes, etc)\nNONE_OF_THE_ABOVE: None of the above",
+      "description": "https://build.fhir.org/valueset-medicationrequest-admin-location.html",
       "enum": [
         "INPATIENT",
         "OUTPATIENT",
@@ -138,7 +141,7 @@
       "type": "string"
     },
     "RxClassImmunosuppression": {
-      "description": "Immunosuppressive drug class or therapy modality.\n\nANTIMET: Anti-Metabolite (e.g., azathioprine, mycophenolate)\nCNI: Calcineurin Inhibitor (e.g., tacrolimus, cyclosporine)\nSTEROID: Corticosteroid (e.g., prednisone, methylprednisolone)\nMTOR: mTOR Inhibitor (e.g., sirolimus, everolimus)\nCOSTIM: Costimulation Blocker/blockade (e.g., belatacept)\nIVIG: Immunoglobulin (e.g., IVIG, Cytogam)\nPOLYCLONAL: Polyclonal antibody (e.g., ATG, ALG)\nMONOCLONAL: Monoclonal antibody (mAb, e.g., basiliximab, rituximab)\nOTHER: Other immunosuppressive drug\nNONE: None of the above",
+      "description": "Immunosuppressive drug class or therapy modality.",
       "enum": [
         "ANTIMET",
         "CNI",
@@ -155,7 +158,6 @@
       "type": "string"
     },
     "RxFrequency": {
-      "description": "QD: once daily (1x/day)\nBID: twice daily (2x/day)\nTID: three times daily (3x/day)\nQID: four times daily (4x/day)\nQOD: every other day (1/2x/day)\nQ6H: every 6 hours (4x/day)\nQ8H: every 8 hours (3x/day)\nQ12H: every 12 hours (2x/day)\nWEEKLY: once every 7 days\nQ2W: once every 2 weeks (14 days)\nQ4W: once every 4 weeks (28 days)\nMONTHLY: once every 4 weeks (28 days)\nOTHER: use timing_text for non-standard frequency\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
         "QD",
         "BID",
@@ -176,7 +178,7 @@
       "type": "string"
     },
     "RxIngredientImmunosuppression": {
-      "description": "The specific immunosuppressive drug ingredient.\n\nANTIMET group: AZA=Azathioprine, MMF=Mycophenolate Mofetil, ANTIMET_OTHER=Other anti-metabolite\nCNI group: CYA=Cyclosporine, TAC=Tacrolimus, CNI_OTHER=Other calcineurin inhibitor\nSTEROID group: MEDROL=Methylprednisolone, PDL=Prednisolone, PRED=Prednisone, STEROID_OTHER=Other corticosteroid\nCOSTIM group: BEL=Belatacept, ABA=Abatacept, COSTIM_OTHER=Other costimulation blocker\nIVIG group: IVIG=Intravenous Immunoglobulin, CYTOGAM=Cytogam (CMV-specific hyperimmune globulin), IVIG_OTHER=Other immunoglobulin\nMTOR group: EVE=Everolimus, SRL=Sirolimus, MTOR_OTHER=Other mTOR inhibitor\nMONOCLONAL group: ALEM=Alemtuzumab, BASI=Basiliximab, DAC=Daclizumab, RTX=Rituximab, MONOCLONAL_OTHER=Other monoclonal antibody\nPOLYCLONAL group: ATG=Antithymocyte Globulin, POLYCLONAL_OTHER=Other polyclonal antibody\nNONE: None of the above",
+      "description": "The specific immunosuppressive drug ingredient.",
       "enum": [
         "AZA",
         "MMF",
@@ -210,7 +212,7 @@
       "type": "string"
     },
     "RxQuantityUnit": {
-      "description": "UCUM unit codes for medication quantity.\n\nMass: MG=mg, G=g, UG=ug (microgram/mcg), KG=kg\nVolume: ML=mL, L=L\nInternational Units: U=U, IU=[iU]\nCountable: TABLET={tablet}, CAPSULE={capsule}, PUFF={puff}, PATCH={patch}, SUPPOSITORY={suppository}\nRatios: MG_PER_ML=mg/mL, MG_PER_KG=mg/kg, U_PER_KG=U/kg, UG_PER_KG_PER_MIN=ug/kg/min\nTime (infusion rates): H=h, MIN=min, D=d\nNONE_OF_THE_ABOVE: None of the above",
+      "description": "UCUM unit codes for medication quantity.",
       "enum": [
         "MG",
         "G",
@@ -238,7 +240,7 @@
       "type": "string"
     },
     "RxRoute": {
-      "description": "Route of Administration can \"help\" (but not deterministic) for drug metadata, examples\n* Injection --> antibody for induction/rescue therapy\n* Topical --> skin lesions\n* Inhalation --> Steroid\nhttps://build.fhir.org/valueset-route-codes.html\n\nPO: Oral (includes swallowed and sublingual routes)\nNG: Nasogastric/Feeding tube (NG/PEG)\nINJECTION: Injection (IV, SC, or IM)\nINHALATION: Inhalation (respiratory route)\nTOPICAL: Topical (skin or mucosal surface)\nNONE_OF_THE_ABOVE: None of the above",
+      "description": "Route of Administration can \"help\" (but not deterministic) for drug metadata, examples\n* Injection --> antibody for induction/rescue therapy\n* Topical --> skin lesions\n* Inhalation --> Steroid\nhttps://build.fhir.org/valueset-route-codes.html",
       "enum": [
         "PO",
         "NG",
@@ -251,7 +253,7 @@
       "type": "string"
     },
     "RxStatus": {
-      "description": "Medication Status (including Intent because chart review is NOT always identical to Med Request)\nhttps://build.fhir.org/valueset-medicationrequest-status.html\nhttps://build.fhir.org/valueset-medicationrequest-intent.html\n\nACTIVE: Medication order is active (currently prescribed and intended for ongoing use).\nINTENDED: Medication is planned/ordered/prescribed but therapy has not yet started.\nCOMPLETED: Medication course is finished (all doses given or intended duration completed).\nSTOPPED: Medication was stopped or permanently discontinued before completion.\nCANCELED: Medication order was canceled/withdrawn before any doses were administered.\nON_HOLD: Medication is temporarily paused (on-hold, suspended, or interrupted).\nNONE_OF_THE_ABOVE: None of the above",
+      "description": "Medication Status (including Intent because chart review is NOT always identical to Med Request)\nhttps://build.fhir.org/valueset-medicationrequest-status.html\nhttps://build.fhir.org/valueset-medicationrequest-intent.html",
       "enum": [
         "ACTIVE",
         "INTENDED",
@@ -265,7 +267,6 @@
       "type": "string"
     },
     "TreatmentPhase": {
-      "description": "Treatment Phase\n\nINDUCTION: Induction therapy\nMAINTENANCE: Maintenance therapy\nRESCUE: Rescue therapy\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
         "INDUCTION",
         "MAINTENANCE",

--- a/cumulus_library_kidney_transplant/llm/schemas/irae_multiple_transplant_history.json
+++ b/cumulus_library_kidney_transplant/llm/schemas/irae_multiple_transplant_history.json
@@ -4,13 +4,12 @@
       "description": "Does this patient have a history of multiple transplants, renal or otherwise?\nFor use in reevaluating the patients in our cohort, excluding patients with a history\nof multiple transplants from our analysis.",
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -24,6 +23,10 @@
           "type": "boolean"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "MultipleTransplantHistoryMention",
       "type": "object"
     }

--- a/cumulus_library_kidney_transplant/llm/schemas/irae_outcomes.json
+++ b/cumulus_library_kidney_transplant/llm/schemas/irae_outcomes.json
@@ -24,18 +24,19 @@
         },
         "bacterial_infection": {
           "$ref": "#/$defs/BacterialInfectionPresent",
-          "default": "None of the above",
-          "description": "What evidence documents bacterial infection as current, active, or being evaluated/treated now?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "What evidence documents bacterial infection as current, active, or being evaluated/treated now? CONFIRMED: Bacterial infection confirmed by laboratory test or imaging, bacterial infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to bacterial infection; SUSPECTED: Bacterial infection is suspected, likely, cannot be ruled out, bacterial infection is a differential diagnosis or bacterial test result is pending; NONE_OF_THE_ABOVE: None of the above"
         }
       },
       "title": "BacterialInfectionMention",
       "type": "object"
     },
     "BacterialInfectionPresent": {
+      "description": "CONFIRMED: Bacterial infection confirmed by laboratory test or imaging, bacterial infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to bacterial infection\nSUSPECTED: Bacterial infection is suspected, likely, cannot be ruled out, bacterial infection is a differential diagnosis or bacterial test result is pending\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "Bacterial infection confirmed by laboratory test or imaging, bacterial infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to bacterial infection",
-        "Bacterial infection is suspected, likely, cannot be ruled out, bacterial infection is a differential diagnosis or bacterial test result is pending",
-        "None of the above"
+        "CONFIRMED",
+        "SUSPECTED",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "BacterialInfectionPresent",
       "type": "string"
@@ -64,20 +65,20 @@
         },
         "cancer": {
           "$ref": "#/$defs/CancerPresent",
-          "default": "None of the above",
-          "description": "What evidence documents cancer as current, active, or being evaluated/treated now?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "What evidence documents cancer as current, active, or being evaluated/treated now? BIOPSY_PROVEN: Biopsy proven or pathology proven cancer; CONFIRMED: Cancer was 'diagnosed', 'confirmed' or 'positive'; SUSPECTED: Cancer is presumed, suspected, likely, cannot be ruled out, biopsy of any lesion, or treatment with chemotherapy/radiation; NONE_OF_THE_ABOVE: None of the above"
         }
       },
       "title": "CancerMention",
       "type": "object"
     },
     "CancerPresent": {
-      "description": "Notice: Cancer treatments may also be used in 'rescue' therapy (DSA/graft rejection).\nPTLD is a type of cancer. PTLD is a lymphoma and thus not treated with \"surgical excision\".\nSkin cancer (of which there are many types carcinoma and melanoma) is treated with surgical excision.",
+      "description": "Notice: Cancer treatments may also be used in 'rescue' therapy (DSA/graft rejection).\nPTLD is a type of cancer. PTLD is a lymphoma and thus not treated with \"surgical excision\".\nSkin cancer (of which there are many types carcinoma and melanoma) is treated with surgical excision.\n\nBIOPSY_PROVEN: Biopsy proven or pathology proven cancer\nCONFIRMED: Cancer was 'diagnosed', 'confirmed' or 'positive'\nSUSPECTED: Cancer is presumed, suspected, likely, cannot be ruled out, biopsy of any lesion, or treatment with chemotherapy/radiation\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "Biopsy proven or pathology proven cancer",
-        "Cancer was 'diagnosed', 'confirmed' or 'positive'",
-        "Cancer is presumed, suspected, likely, cannot be ruled out, biopsy of any lesion, or treatment with chemotherapy/radiation",
-        "None of the above"
+        "BIOPSY_PROVEN",
+        "CONFIRMED",
+        "SUSPECTED",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "CancerPresent",
       "type": "string"
@@ -106,19 +107,19 @@
         },
         "dsa": {
           "$ref": "#/$defs/DSAPresent",
-          "default": "None of the above",
-          "description": "What evidence documents donor specific antibodies (DSA) as current, active, or being evaluated/treated now?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "What evidence documents donor specific antibodies (DSA) as current, active, or being evaluated/treated now? CONFIRMED: DSA diagnostic test positive, DSA diagnosis 'confirmed' or 'positive', or increase in immunosuppression due to DSA; SUSPECTED: DSA suspected, DSA likely, DSA cannot be ruled out, DSA test result pending, or treatment with IVIG/plasmapheresis; NONE_OF_THE_ABOVE: None of the above"
         }
       },
       "title": "DSAMention",
       "type": "object"
     },
     "DSAPresent": {
-      "description": "Notice: DSA is strongly related to `GraftRejectionPresent`.\n\nTreatment of DSA includes immunosuppressive drugs, IVIG, and plasmapheresis (PLEX).\n\nTreatment with immunosuppressive drugs does *NOT* imply SUSPECTED DSA,\nas many of immunosuppressive drugs are routinely used for \"maintenance\" therapy.\n\nIVIG and plasmapheresis (PLEX) during the post-transplant (post induction) phase DOES imply\n--> DSAPresent >  SUSPECTED (and possibly CONFIRMED)\n--> `GraftRejectionPresent` > SUSPECTED (and possibly CONFIRMED or BIOPSY_PROVEN)",
+      "description": "Notice: DSA is strongly related to `GraftRejectionPresent`.\n\nTreatment of DSA includes immunosuppressive drugs, IVIG, and plasmapheresis (PLEX).\n\nTreatment with immunosuppressive drugs does *NOT* imply SUSPECTED DSA,\nas many of immunosuppressive drugs are routinely used for \"maintenance\" therapy.\n\nIVIG and plasmapheresis (PLEX) during the post-transplant (post induction) phase DOES imply\n--> DSAPresent > SUSPECTED (and possibly CONFIRMED)\n--> `GraftRejectionPresent` > SUSPECTED (and possibly CONFIRMED or BIOPSY_PROVEN)\n\nCONFIRMED: DSA diagnostic test positive, DSA diagnosis 'confirmed' or 'positive', or increase in immunosuppression due to DSA\nSUSPECTED: DSA suspected, DSA likely, DSA cannot be ruled out, DSA test result pending, or treatment with IVIG/plasmapheresis\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "DSA diagnostic test positive, DSA diagnosis 'confirmed' or 'positive', or increase in immunosuppression due to DSA",
-        "DSA suspected, DSA likely, DSA cannot be ruled out, DSA test result pending, or treatment with IVIG/plasmapheresis",
-        "None of the above"
+        "CONFIRMED",
+        "SUSPECTED",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "DSAPresent",
       "type": "string"
@@ -193,18 +194,19 @@
         },
         "fungal_infection": {
           "$ref": "#/$defs/FungalInfectionPresent",
-          "default": "None of the above",
-          "description": "What evidence documents fungal infection as current, active, or being evaluated/treated now?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "What evidence documents fungal infection as current, active, or being evaluated/treated now? CONFIRMED: Fungal infection confirmed by laboratory test or imaging, fungal infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to fungal infection; SUSPECTED: Fungal infection is suspected, likely, cannot be ruled out, fungal infection is a differential diagnosis or fungal test result is pending; NONE_OF_THE_ABOVE: None of the above"
         }
       },
       "title": "FungalInfectionMention",
       "type": "object"
     },
     "FungalInfectionPresent": {
+      "description": "CONFIRMED: Fungal infection confirmed by laboratory test or imaging, fungal infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to fungal infection\nSUSPECTED: Fungal infection is suspected, likely, cannot be ruled out, fungal infection is a differential diagnosis or fungal test result is pending\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "Fungal infection confirmed by laboratory test or imaging, fungal infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to fungal infection",
-        "Fungal infection is suspected, likely, cannot be ruled out, fungal infection is a differential diagnosis or fungal test result is pending",
-        "None of the above"
+        "CONFIRMED",
+        "SUSPECTED",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "FungalInfectionPresent",
       "type": "string"
@@ -233,18 +235,19 @@
         },
         "graft_failure": {
           "$ref": "#/$defs/GraftFailurePresent",
-          "default": "None of the above",
-          "description": "What evidence documents kidney graft failure as current, active, or being evaluated/treated now?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "What evidence documents kidney graft failure as current, active, or being evaluated/treated now? CONFIRMED: Kidney graft has failed or kidney graft loss; SUSPECTED: Kidney graft failure presumed, suspected, likely, or cannot be ruled out; NONE_OF_THE_ABOVE: None of the above"
         }
       },
       "title": "GraftFailureMention",
       "type": "object"
     },
     "GraftFailurePresent": {
+      "description": "CONFIRMED: Kidney graft has failed or kidney graft loss\nSUSPECTED: Kidney graft failure presumed, suspected, likely, or cannot be ruled out\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "Kidney graft has failed or kidney graft loss",
-        "Kidney graft failure presumed, suspected, likely, or cannot be ruled out",
-        "None of the above"
+        "CONFIRMED",
+        "SUSPECTED",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "GraftFailurePresent",
       "type": "string"
@@ -273,20 +276,20 @@
         },
         "graft_rejection": {
           "$ref": "#/$defs/GraftRejectionPresent",
-          "default": "None of the above",
-          "description": "What evidence documents kidney graft rejection as current, active, or being evaluated/treated now?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "What evidence documents kidney graft rejection as current, active, or being evaluated/treated now? BIOPSY_PROVEN: Biopsy proven kidney graft rejection or pathology proven kidney graft rejection; CONFIRMED: Kidney graft rejection was 'diagnosed', 'confirmed' or 'positive'; SUSPECTED: Kidney graft rejection presumed, suspected, likely, cannot be ruled out, biopsy result pending, or treatment with IVIG/plasmapheresis; NONE_OF_THE_ABOVE: None of the above"
         }
       },
       "title": "GraftRejectionMention",
       "type": "object"
     },
     "GraftRejectionPresent": {
-      "description": "Notice: Graft rejection is strongly related to `DSAPresent`.\n\nTreatment of graft rejection includes immunosuppressive drugs, IVIG, and plasmapheresis (PLEX).\n\nTreatment with immunosuppressive drugs does *NOT* imply outcome is SUSPECTED,\nas many of immunosuppressive drugs are routinely used for \"maintenance\" therapy.\n\nIVIG and plasmapheresis (PLEX) during the post-transplant (post induction) phase DOES imply\n--> `GraftRejectionPresent` > SUSPECTED (and possibly CONFIRMED or BIOPSY_PROVEN)\n--> DSAPresent >  SUSPECTED (and possibly CONFIRMED)",
+      "description": "Notice: Graft rejection is strongly related to `DSAPresent`.\n\nTreatment of graft rejection includes immunosuppressive drugs, IVIG, and plasmapheresis (PLEX).\n\nTreatment with immunosuppressive drugs does *NOT* imply outcome is SUSPECTED,\nas many of immunosuppressive drugs are routinely used for \"maintenance\" therapy.\n\nIVIG and plasmapheresis (PLEX) during the post-transplant (post induction) phase DOES imply\n--> `GraftRejectionPresent` > SUSPECTED (and possibly CONFIRMED or BIOPSY_PROVEN)\n--> DSAPresent > SUSPECTED (and possibly CONFIRMED)\n\nBIOPSY_PROVEN: Biopsy proven kidney graft rejection or pathology proven kidney graft rejection\nCONFIRMED: Kidney graft rejection was 'diagnosed', 'confirmed' or 'positive'\nSUSPECTED: Kidney graft rejection presumed, suspected, likely, cannot be ruled out, biopsy result pending, or treatment with IVIG/plasmapheresis\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "Biopsy proven kidney graft rejection or pathology proven kidney graft rejection",
-        "Kidney graft rejection was 'diagnosed', 'confirmed' or 'positive'",
-        "Kidney graft rejection presumed, suspected, likely, cannot be ruled out, biopsy result pending, or treatment with IVIG/plasmapheresis",
-        "None of the above"
+        "BIOPSY_PROVEN",
+        "CONFIRMED",
+        "SUSPECTED",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "GraftRejectionPresent",
       "type": "string"
@@ -315,18 +318,19 @@
         },
         "infection": {
           "$ref": "#/$defs/InfectionPresent",
-          "default": "None of the above",
-          "description": "What evidence documents infection as current, active, or being evaluated/treated now?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "What evidence documents infection as current, active, or being evaluated/treated now? CONFIRMED: Infection confirmed by laboratory test or imaging, infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to infection; SUSPECTED: Infection is suspected, likely, cannot be ruled out, infection is a differential diagnosis or infectious test result is pending; NONE_OF_THE_ABOVE: None of the above"
         }
       },
       "title": "InfectionMention",
       "type": "object"
     },
     "InfectionPresent": {
+      "description": "CONFIRMED: Infection confirmed by laboratory test or imaging, infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to infection\nSUSPECTED: Infection is suspected, likely, cannot be ruled out, infection is a differential diagnosis or infectious test result is pending\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "Infection confirmed by laboratory test or imaging, infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to infection",
-        "Infection is suspected, likely, cannot be ruled out, infection is a differential diagnosis or infectious test result is pending",
-        "None of the above"
+        "CONFIRMED",
+        "SUSPECTED",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "InfectionPresent",
       "type": "string"
@@ -355,30 +359,31 @@
         },
         "ptld": {
           "$ref": "#/$defs/PTLDPresent",
-          "default": "None of the above",
-          "description": "What evidence documents post transplant lymphoproliferative disorder (PTLD) as current, active, or being evaluated/treated now?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "What evidence documents post transplant lymphoproliferative disorder (PTLD) as current, active, or being evaluated/treated now? BIOPSY_PROVEN: Biopsy proven or pathology proven PTLD; CONFIRMED: PTLD was 'diagnosed', 'confirmed' or 'positive' or viral positive lymphoma; SUSPECTED: PTLD presumed, suspected, likely, cannot be ruled out, PTLD biopsy result pending, or treatment with chemotherapy/radiation; NONE_OF_THE_ABOVE: None of the above"
         }
       },
       "title": "PTLDMention",
       "type": "object"
     },
     "PTLDPresent": {
-      "description": "Notice: PTLD treatments may also be used in 'rescue' therapy (DSA/graft rejection) or other cancers.\nOne notable difference from other cancers (such as skin cancer) is the absence of \"surgical excision\" (lymphoma).",
+      "description": "Notice: PTLD treatments may also be used in 'rescue' therapy (DSA/graft rejection) or other cancers.\nOne notable difference from other cancers (such as skin cancer) is the absence of \"surgical excision\" (lymphoma).\n\nBIOPSY_PROVEN: Biopsy proven or pathology proven PTLD\nCONFIRMED: PTLD was 'diagnosed', 'confirmed' or 'positive' or viral positive lymphoma\nSUSPECTED: PTLD presumed, suspected, likely, cannot be ruled out, PTLD biopsy result pending, or treatment with chemotherapy/radiation\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "Biopsy proven or pathology proven PTLD",
-        "PTLD was 'diagnosed', 'confirmed' or 'positive' or viral positive lymphoma",
-        "PTLD presumed, suspected, likely, cannot be ruled out, PTLD biopsy result pending, or treatment with chemotherapy/radiation",
-        "None of the above"
+        "BIOPSY_PROVEN",
+        "CONFIRMED",
+        "SUSPECTED",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "PTLDPresent",
       "type": "string"
     },
     "RxCompliance": {
+      "description": "COMPLIANT: Patient is documented as compliant with immunosuppressive medications.\nPARTIALLY_COMPLIANT: Patient is documented as only partially compliant with immunosuppressive medications.\nNON_COMPLIANT: Patient is documented as noncompliant with immunosuppressive medications.\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "Patient is documented as compliant with immunosuppressive medications.",
-        "Patient is documented as only partially compliant with immunosuppressive medications.",
-        "Patient is documented as noncompliant with immunosuppressive medications.",
-        "None of the above"
+        "COMPLIANT",
+        "PARTIALLY_COMPLIANT",
+        "NON_COMPLIANT",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "RxCompliance",
       "type": "string"
@@ -401,19 +406,20 @@
         },
         "rx_compliance": {
           "$ref": "#/$defs/RxCompliance",
-          "default": "None of the above",
-          "description": "In the present encounter, is the patient documented as compliant with immunosuppressive medications?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "In the present encounter, is the patient documented as compliant with immunosuppressive medications? COMPLIANT: Patient is documented as compliant with immunosuppressive medications; PARTIALLY_COMPLIANT: Patient is documented as only partially compliant with immunosuppressive medications; NON_COMPLIANT: Patient is documented as noncompliant with immunosuppressive medications; NONE_OF_THE_ABOVE: None of the above"
         }
       },
       "title": "RxComplianceMention",
       "type": "object"
     },
     "RxTherapeuticStatus": {
+      "description": "THERAPEUTIC: Immunosuppression levels are documented as therapeutic, adequate, or within target range.\nSUB_THERAPEUTIC: Immunosuppression levels are documented as subtherapeutic, insufficient, or below target range.\nSUPRA_THERAPEUTIC: Immunosuppression levels are documented as supratherapeutic, above therapeutic level, or above target range.\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "Immunosuppression levels are documented as therapeutic, adequate, or within target range.",
-        "Immunosuppression levels are documented as subtherapeutic, insufficient, or below target range.",
-        "Immunosuppression levels are documented as supratherapeutic, above therapeutic level, or above target range.",
-        "None of the above"
+        "THERAPEUTIC",
+        "SUB_THERAPEUTIC",
+        "SUPRA_THERAPEUTIC",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "RxTherapeuticStatus",
       "type": "string"
@@ -436,8 +442,8 @@
         },
         "rx_therapeutic_status": {
           "$ref": "#/$defs/RxTherapeuticStatus",
-          "default": "None of the above",
-          "description": "In the present encounter, what is the documented immunosuppression level?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "In the present encounter, what is the documented immunosuppression level? THERAPEUTIC: Immunosuppression levels are documented as therapeutic, adequate, or within target range; SUB_THERAPEUTIC: Immunosuppression levels are documented as subtherapeutic, insufficient, or below target range; SUPRA_THERAPEUTIC: Immunosuppression levels are documented as supratherapeutic, above therapeutic level, or above target range; NONE_OF_THE_ABOVE: None of the above"
         }
       },
       "title": "RxTherapeuticStatusMention",
@@ -467,18 +473,19 @@
         },
         "viral_infection": {
           "$ref": "#/$defs/ViralInfectionPresent",
-          "default": "None of the above",
-          "description": "What evidence documents viral infection as current, active, or being evaluated/treated now?"
+          "default": "NONE_OF_THE_ABOVE",
+          "description": "What evidence documents viral infection as current, active, or being evaluated/treated now? CONFIRMED: Viral infection confirmed by laboratory test or imaging, viral infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to viral infection; SUSPECTED: Viral infection is suspected, likely, cannot be ruled out, viral infection is a differential diagnosis or viral test result is pending; NONE_OF_THE_ABOVE: None of the above"
         }
       },
       "title": "ViralInfectionMention",
       "type": "object"
     },
     "ViralInfectionPresent": {
+      "description": "CONFIRMED: Viral infection confirmed by laboratory test or imaging, viral infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to viral infection\nSUSPECTED: Viral infection is suspected, likely, cannot be ruled out, viral infection is a differential diagnosis or viral test result is pending\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
-        "Viral infection confirmed by laboratory test or imaging, viral infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to viral infection",
-        "Viral infection is suspected, likely, cannot be ruled out, viral infection is a differential diagnosis or viral test result is pending",
-        "None of the above"
+        "CONFIRMED",
+        "SUSPECTED",
+        "NONE_OF_THE_ABOVE"
       ],
       "title": "ViralInfectionPresent",
       "type": "string"

--- a/cumulus_library_kidney_transplant/llm/schemas/irae_outcomes.json
+++ b/cumulus_library_kidney_transplant/llm/schemas/irae_outcomes.json
@@ -3,13 +3,12 @@
     "BacterialInfectionMention": {
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -28,11 +27,14 @@
           "description": "What evidence documents bacterial infection as current, active, or being evaluated/treated now? CONFIRMED: Bacterial infection confirmed by laboratory test or imaging, bacterial infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to bacterial infection; SUSPECTED: Bacterial infection is suspected, likely, cannot be ruled out, bacterial infection is a differential diagnosis or bacterial test result is pending; NONE_OF_THE_ABOVE: None of the above"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "BacterialInfectionMention",
       "type": "object"
     },
     "BacterialInfectionPresent": {
-      "description": "CONFIRMED: Bacterial infection confirmed by laboratory test or imaging, bacterial infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to bacterial infection\nSUSPECTED: Bacterial infection is suspected, likely, cannot be ruled out, bacterial infection is a differential diagnosis or bacterial test result is pending\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
         "CONFIRMED",
         "SUSPECTED",
@@ -44,13 +46,12 @@
     "CancerMention": {
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -69,11 +70,15 @@
           "description": "What evidence documents cancer as current, active, or being evaluated/treated now? BIOPSY_PROVEN: Biopsy proven or pathology proven cancer; CONFIRMED: Cancer was 'diagnosed', 'confirmed' or 'positive'; SUSPECTED: Cancer is presumed, suspected, likely, cannot be ruled out, biopsy of any lesion, or treatment with chemotherapy/radiation; NONE_OF_THE_ABOVE: None of the above"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "CancerMention",
       "type": "object"
     },
     "CancerPresent": {
-      "description": "Notice: Cancer treatments may also be used in 'rescue' therapy (DSA/graft rejection).\nPTLD is a type of cancer. PTLD is a lymphoma and thus not treated with \"surgical excision\".\nSkin cancer (of which there are many types carcinoma and melanoma) is treated with surgical excision.\n\nBIOPSY_PROVEN: Biopsy proven or pathology proven cancer\nCONFIRMED: Cancer was 'diagnosed', 'confirmed' or 'positive'\nSUSPECTED: Cancer is presumed, suspected, likely, cannot be ruled out, biopsy of any lesion, or treatment with chemotherapy/radiation\nNONE_OF_THE_ABOVE: None of the above",
+      "description": "Notice: Cancer treatments may also be used in 'rescue' therapy (DSA/graft rejection).\nPTLD is a type of cancer. PTLD is a lymphoma and thus not treated with \"surgical excision\".\nSkin cancer (of which there are many types carcinoma and melanoma) is treated with surgical excision.",
       "enum": [
         "BIOPSY_PROVEN",
         "CONFIRMED",
@@ -86,13 +91,12 @@
     "DSAMention": {
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -111,11 +115,15 @@
           "description": "What evidence documents donor specific antibodies (DSA) as current, active, or being evaluated/treated now? CONFIRMED: DSA diagnostic test positive, DSA diagnosis 'confirmed' or 'positive', or increase in immunosuppression due to DSA; SUSPECTED: DSA suspected, DSA likely, DSA cannot be ruled out, DSA test result pending, or treatment with IVIG/plasmapheresis; NONE_OF_THE_ABOVE: None of the above"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "DSAMention",
       "type": "object"
     },
     "DSAPresent": {
-      "description": "Notice: DSA is strongly related to `GraftRejectionPresent`.\n\nTreatment of DSA includes immunosuppressive drugs, IVIG, and plasmapheresis (PLEX).\n\nTreatment with immunosuppressive drugs does *NOT* imply SUSPECTED DSA,\nas many of immunosuppressive drugs are routinely used for \"maintenance\" therapy.\n\nIVIG and plasmapheresis (PLEX) during the post-transplant (post induction) phase DOES imply\n--> DSAPresent > SUSPECTED (and possibly CONFIRMED)\n--> `GraftRejectionPresent` > SUSPECTED (and possibly CONFIRMED or BIOPSY_PROVEN)\n\nCONFIRMED: DSA diagnostic test positive, DSA diagnosis 'confirmed' or 'positive', or increase in immunosuppression due to DSA\nSUSPECTED: DSA suspected, DSA likely, DSA cannot be ruled out, DSA test result pending, or treatment with IVIG/plasmapheresis\nNONE_OF_THE_ABOVE: None of the above",
+      "description": "Notice: DSA is strongly related to `GraftRejectionPresent`.\n\nTreatment of DSA includes immunosuppressive drugs, IVIG, and plasmapheresis (PLEX).\n\nTreatment with immunosuppressive drugs does *NOT* imply SUSPECTED DSA,\nas many of immunosuppressive drugs are routinely used for \"maintenance\" therapy.\n\nIVIG and plasmapheresis (PLEX) during the post-transplant (post induction) phase DOES imply\n--> DSAPresent > SUSPECTED (and possibly CONFIRMED)\n--> `GraftRejectionPresent` > SUSPECTED (and possibly CONFIRMED or BIOPSY_PROVEN)",
       "enum": [
         "CONFIRMED",
         "SUSPECTED",
@@ -127,13 +135,12 @@
     "DeceasedMention": {
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -167,19 +174,22 @@
           "title": "Deceased Date"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "DeceasedMention",
       "type": "object"
     },
     "FungalInfectionMention": {
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -198,11 +208,14 @@
           "description": "What evidence documents fungal infection as current, active, or being evaluated/treated now? CONFIRMED: Fungal infection confirmed by laboratory test or imaging, fungal infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to fungal infection; SUSPECTED: Fungal infection is suspected, likely, cannot be ruled out, fungal infection is a differential diagnosis or fungal test result is pending; NONE_OF_THE_ABOVE: None of the above"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "FungalInfectionMention",
       "type": "object"
     },
     "FungalInfectionPresent": {
-      "description": "CONFIRMED: Fungal infection confirmed by laboratory test or imaging, fungal infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to fungal infection\nSUSPECTED: Fungal infection is suspected, likely, cannot be ruled out, fungal infection is a differential diagnosis or fungal test result is pending\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
         "CONFIRMED",
         "SUSPECTED",
@@ -214,13 +227,12 @@
     "GraftFailureMention": {
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -239,11 +251,14 @@
           "description": "What evidence documents kidney graft failure as current, active, or being evaluated/treated now? CONFIRMED: Kidney graft has failed or kidney graft loss; SUSPECTED: Kidney graft failure presumed, suspected, likely, or cannot be ruled out; NONE_OF_THE_ABOVE: None of the above"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "GraftFailureMention",
       "type": "object"
     },
     "GraftFailurePresent": {
-      "description": "CONFIRMED: Kidney graft has failed or kidney graft loss\nSUSPECTED: Kidney graft failure presumed, suspected, likely, or cannot be ruled out\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
         "CONFIRMED",
         "SUSPECTED",
@@ -255,13 +270,12 @@
     "GraftRejectionMention": {
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -280,11 +294,15 @@
           "description": "What evidence documents kidney graft rejection as current, active, or being evaluated/treated now? BIOPSY_PROVEN: Biopsy proven kidney graft rejection or pathology proven kidney graft rejection; CONFIRMED: Kidney graft rejection was 'diagnosed', 'confirmed' or 'positive'; SUSPECTED: Kidney graft rejection presumed, suspected, likely, cannot be ruled out, biopsy result pending, or treatment with IVIG/plasmapheresis; NONE_OF_THE_ABOVE: None of the above"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "GraftRejectionMention",
       "type": "object"
     },
     "GraftRejectionPresent": {
-      "description": "Notice: Graft rejection is strongly related to `DSAPresent`.\n\nTreatment of graft rejection includes immunosuppressive drugs, IVIG, and plasmapheresis (PLEX).\n\nTreatment with immunosuppressive drugs does *NOT* imply outcome is SUSPECTED,\nas many of immunosuppressive drugs are routinely used for \"maintenance\" therapy.\n\nIVIG and plasmapheresis (PLEX) during the post-transplant (post induction) phase DOES imply\n--> `GraftRejectionPresent` > SUSPECTED (and possibly CONFIRMED or BIOPSY_PROVEN)\n--> DSAPresent > SUSPECTED (and possibly CONFIRMED)\n\nBIOPSY_PROVEN: Biopsy proven kidney graft rejection or pathology proven kidney graft rejection\nCONFIRMED: Kidney graft rejection was 'diagnosed', 'confirmed' or 'positive'\nSUSPECTED: Kidney graft rejection presumed, suspected, likely, cannot be ruled out, biopsy result pending, or treatment with IVIG/plasmapheresis\nNONE_OF_THE_ABOVE: None of the above",
+      "description": "Notice: Graft rejection is strongly related to `DSAPresent`.\n\nTreatment of graft rejection includes immunosuppressive drugs, IVIG, and plasmapheresis (PLEX).\n\nTreatment with immunosuppressive drugs does *NOT* imply outcome is SUSPECTED,\nas many of immunosuppressive drugs are routinely used for \"maintenance\" therapy.\n\nIVIG and plasmapheresis (PLEX) during the post-transplant (post induction) phase DOES imply\n--> `GraftRejectionPresent` > SUSPECTED (and possibly CONFIRMED or BIOPSY_PROVEN)\n--> DSAPresent > SUSPECTED (and possibly CONFIRMED)",
       "enum": [
         "BIOPSY_PROVEN",
         "CONFIRMED",
@@ -297,13 +315,12 @@
     "InfectionMention": {
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -322,11 +339,14 @@
           "description": "What evidence documents infection as current, active, or being evaluated/treated now? CONFIRMED: Infection confirmed by laboratory test or imaging, infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to infection; SUSPECTED: Infection is suspected, likely, cannot be ruled out, infection is a differential diagnosis or infectious test result is pending; NONE_OF_THE_ABOVE: None of the above"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "InfectionMention",
       "type": "object"
     },
     "InfectionPresent": {
-      "description": "CONFIRMED: Infection confirmed by laboratory test or imaging, infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to infection\nSUSPECTED: Infection is suspected, likely, cannot be ruled out, infection is a differential diagnosis or infectious test result is pending\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
         "CONFIRMED",
         "SUSPECTED",
@@ -338,13 +358,12 @@
     "PTLDMention": {
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -363,11 +382,15 @@
           "description": "What evidence documents post transplant lymphoproliferative disorder (PTLD) as current, active, or being evaluated/treated now? BIOPSY_PROVEN: Biopsy proven or pathology proven PTLD; CONFIRMED: PTLD was 'diagnosed', 'confirmed' or 'positive' or viral positive lymphoma; SUSPECTED: PTLD presumed, suspected, likely, cannot be ruled out, PTLD biopsy result pending, or treatment with chemotherapy/radiation; NONE_OF_THE_ABOVE: None of the above"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "PTLDMention",
       "type": "object"
     },
     "PTLDPresent": {
-      "description": "Notice: PTLD treatments may also be used in 'rescue' therapy (DSA/graft rejection) or other cancers.\nOne notable difference from other cancers (such as skin cancer) is the absence of \"surgical excision\" (lymphoma).\n\nBIOPSY_PROVEN: Biopsy proven or pathology proven PTLD\nCONFIRMED: PTLD was 'diagnosed', 'confirmed' or 'positive' or viral positive lymphoma\nSUSPECTED: PTLD presumed, suspected, likely, cannot be ruled out, PTLD biopsy result pending, or treatment with chemotherapy/radiation\nNONE_OF_THE_ABOVE: None of the above",
+      "description": "Notice: PTLD treatments may also be used in 'rescue' therapy (DSA/graft rejection) or other cancers.\nOne notable difference from other cancers (such as skin cancer) is the absence of \"surgical excision\" (lymphoma).",
       "enum": [
         "BIOPSY_PROVEN",
         "CONFIRMED",
@@ -378,7 +401,6 @@
       "type": "string"
     },
     "RxCompliance": {
-      "description": "COMPLIANT: Patient is documented as compliant with immunosuppressive medications.\nPARTIALLY_COMPLIANT: Patient is documented as only partially compliant with immunosuppressive medications.\nNON_COMPLIANT: Patient is documented as noncompliant with immunosuppressive medications.\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
         "COMPLIANT",
         "PARTIALLY_COMPLIANT",
@@ -391,13 +413,12 @@
     "RxComplianceMention": {
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -410,11 +431,14 @@
           "description": "In the present encounter, is the patient documented as compliant with immunosuppressive medications? COMPLIANT: Patient is documented as compliant with immunosuppressive medications; PARTIALLY_COMPLIANT: Patient is documented as only partially compliant with immunosuppressive medications; NON_COMPLIANT: Patient is documented as noncompliant with immunosuppressive medications; NONE_OF_THE_ABOVE: None of the above"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "RxComplianceMention",
       "type": "object"
     },
     "RxTherapeuticStatus": {
-      "description": "THERAPEUTIC: Immunosuppression levels are documented as therapeutic, adequate, or within target range.\nSUB_THERAPEUTIC: Immunosuppression levels are documented as subtherapeutic, insufficient, or below target range.\nSUPRA_THERAPEUTIC: Immunosuppression levels are documented as supratherapeutic, above therapeutic level, or above target range.\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
         "THERAPEUTIC",
         "SUB_THERAPEUTIC",
@@ -427,13 +451,12 @@
     "RxTherapeuticStatusMention": {
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -446,19 +469,22 @@
           "description": "In the present encounter, what is the documented immunosuppression level? THERAPEUTIC: Immunosuppression levels are documented as therapeutic, adequate, or within target range; SUB_THERAPEUTIC: Immunosuppression levels are documented as subtherapeutic, insufficient, or below target range; SUPRA_THERAPEUTIC: Immunosuppression levels are documented as supratherapeutic, above therapeutic level, or above target range; NONE_OF_THE_ABOVE: None of the above"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "RxTherapeuticStatusMention",
       "type": "object"
     },
     "ViralInfectionMention": {
       "properties": {
         "has_mention": {
-          "default": false,
-          "description": "Whether there is any mention of this variable in the text.",
+          "description": "Indicates whether the concept was mentioned in the text.",
           "title": "Has Mention",
           "type": "boolean"
         },
         "spans": {
-          "description": "The text spans where this variable is mentioned.",
+          "description": "The verbatim text where this concept was mentioned.",
           "items": {
             "type": "string"
           },
@@ -477,11 +503,14 @@
           "description": "What evidence documents viral infection as current, active, or being evaluated/treated now? CONFIRMED: Viral infection confirmed by laboratory test or imaging, viral infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to viral infection; SUSPECTED: Viral infection is suspected, likely, cannot be ruled out, viral infection is a differential diagnosis or viral test result is pending; NONE_OF_THE_ABOVE: None of the above"
         }
       },
+      "required": [
+        "has_mention",
+        "spans"
+      ],
       "title": "ViralInfectionMention",
       "type": "object"
     },
     "ViralInfectionPresent": {
-      "description": "CONFIRMED: Viral infection confirmed by laboratory test or imaging, viral infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to viral infection\nSUSPECTED: Viral infection is suspected, likely, cannot be ruled out, viral infection is a differential diagnosis or viral test result is pending\nNONE_OF_THE_ABOVE: None of the above",
       "enum": [
         "CONFIRMED",
         "SUSPECTED",

--- a/cumulus_library_kidney_transplant/llm/summaries/donor_group_summary.txt
+++ b/cumulus_library_kidney_transplant/llm/summaries/donor_group_summary.txt
@@ -48,7 +48,7 @@ donor_hla_mismatch_count_mention:
 
 donor_serostatus_mention:
     serostatus = Serostatus (Choice Value)
-        # Overall serostatus of the renal donor for ANY virus. Set SEROPOSITIVE if the note documents the donor as seropositive for ANY virus (including CMV, EBV, HBV, HCV, HSV, VZV, or an unspecified virus), or uses generic language such as 'donor is seropositive' without naming the virus. Set SERONEGATIVE only if it explicitly states the donor was seronegative for all IgG tests. Otherwise use NOT_MENTIONED.
+        # Overall serostatus of the renal donor for ANY virus. SEROPOSITIVE: Documented IgG positive / seropositiveSERONEGATIVE: Documented IgG negative / seronegativeNOT_MENTIONED: No serostatus documentation foundSet SEROPOSITIVE if the note documents the donor as seropositive for ANY virus (including CMV, EBV, HBV, HCV, HSV, VZV, or an unspecified virus), or uses generic language such as 'donor is seropositive' without naming the virus. Set SERONEGATIVE only if it explicitly states the donor was seronegative for all IgG tests. Otherwise use NOT_MENTIONED.
         # Possible Values:
         #   - SEROPOSITIVE
         #   - SERONEGATIVE
@@ -57,7 +57,7 @@ donor_serostatus_mention:
 
 donor_serostatus_cmv_mention:
     serostatus = Serostatus (Choice Value)
-        # CMV serostatus of the renal donor. Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. Look for patterns like 'CMV D+', 'CMV D-', 'donor CMV IgG positive', 'donor CMV IgG negative', etc.
+        # CMV serostatus of the renal donor. Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. SEROPOSITIVE: Documented IgG positive / seropositiveSERONEGATIVE: Documented IgG negative / seronegativeNOT_MENTIONED: No serostatus documentation foundLook for patterns like 'CMV D+', 'CMV D-', 'donor CMV IgG positive', 'donor CMV IgG negative', etc.
         # Possible Values:
         #   - SEROPOSITIVE
         #   - SERONEGATIVE
@@ -66,7 +66,7 @@ donor_serostatus_cmv_mention:
 
 donor_serostatus_ebv_mention:
     serostatus = Serostatus (Choice Value)
-        # EBV serostatus of the renal donor. Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. Look for patterns like 'EBV D+', 'EBV D-', 'donor EBV IgG positive', 'donor EBV IgG negative', etc.
+        # EBV serostatus of the renal donor. Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. SEROPOSITIVE: Documented IgG positive / seropositiveSERONEGATIVE: Documented IgG negative / seronegativeNOT_MENTIONED: No serostatus documentation foundLook for patterns like 'EBV D+', 'EBV D-', 'donor EBV IgG positive', 'donor EBV IgG negative', etc.
         # Possible Values:
         #   - SEROPOSITIVE
         #   - SERONEGATIVE
@@ -75,7 +75,7 @@ donor_serostatus_ebv_mention:
 
 recipient_serostatus_mention:
     serostatus = Serostatus (Choice Value)
-        # Serostatus of the recipient at the time of renal transplant for ANY virus. Set SEROPOSITIVE if the note documents the recipient as seropositive for ANY virus (including CMV, EBV, HBV, HCV, HSV, VZV, or an unspecified virus), or if the text states 'recipient is seropositive' without naming the virus. Set SERONEGATIVE only if explicitly stated the recipient was seronegative. Otherwise use NOT_MENTIONED.
+        # Serostatus of the recipient at the time of renal transplant for ANY virus. SEROPOSITIVE: Documented IgG positive / seropositiveSERONEGATIVE: Documented IgG negative / seronegativeNOT_MENTIONED: No serostatus documentation foundSet SEROPOSITIVE if the note documents the recipient as seropositive for ANY virus (including CMV, EBV, HBV, HCV, HSV, VZV, or an unspecified virus), or if the text states 'recipient is seropositive' without naming the virus. Set SERONEGATIVE only if explicitly stated the recipient was seronegative. Otherwise use NOT_MENTIONED.
         # Possible Values:
         #   - SEROPOSITIVE
         #   - SERONEGATIVE
@@ -84,7 +84,7 @@ recipient_serostatus_mention:
 
 recipient_serostatus_cmv_mention:
     serostatus = Serostatus (Choice Value)
-        # CMV serostatus of the recipient at the time of renal transplant. Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. Look for patterns like 'CMV R+', 'CMV R-', 'recipient CMV IgG positive', 'recipient CMV IgG negative', etc.
+        # CMV serostatus of the recipient at the time of renal transplant. SEROPOSITIVE: Documented IgG positive / seropositiveSERONEGATIVE: Documented IgG negative / seronegativeNOT_MENTIONED: No serostatus documentation foundChoose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. Look for patterns like 'CMV R+', 'CMV R-', 'recipient CMV IgG positive', 'recipient CMV IgG negative', etc.
         # Possible Values:
         #   - SEROPOSITIVE
         #   - SERONEGATIVE
@@ -93,7 +93,7 @@ recipient_serostatus_cmv_mention:
 
 recipient_serostatus_ebv_mention:
     serostatus = Serostatus (Choice Value)
-        # EBV serostatus of the recipient at the time of renal transplant. Choose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. Look for patterns like 'EBV R+', 'EBV R-', 'recipient EBV IgG positive', 'recipient EBV IgG negative', etc.
+        # EBV serostatus of the recipient at the time of renal transplant. SEROPOSITIVE: Documented IgG positive / seropositiveSERONEGATIVE: Documented IgG negative / seronegativeNOT_MENTIONED: No serostatus documentation foundChoose one of: 'SEROPOSITIVE', 'SERONEGATIVE', 'NOT_MENTIONED'. Look for patterns like 'EBV R+', 'EBV R-', 'recipient EBV IgG positive', 'recipient EBV IgG negative', etc.
         # Possible Values:
         #   - SEROPOSITIVE
         #   - SERONEGATIVE

--- a/cumulus_library_kidney_transplant/llm/summaries/donor_group_summary.txt
+++ b/cumulus_library_kidney_transplant/llm/summaries/donor_group_summary.txt
@@ -6,44 +6,44 @@ donor_transplant_date_mention:
 
 donor_type_mention:
     donor_type = DonorType (Choice Value)
-        # Was the first renal donor living at the time of renal transplant?
+        # Was the first renal donor living at the time of renal transplant? LIVING: Donor was alive at time of renal transplant; DECEASED: Donor was deceased at time of renal transplant; NOT_MENTIONED: Donor was not mentioned as living or deceased
         # Possible Values:
-        #   - Donor was alive at time of renal transplant
-        #   - Donor was deceased at time of renal transplant
-        #   - Donor was not mentioned as living or deceased
+        #   - LIVING
+        #   - DECEASED
+        #   - NOT_MENTIONED
 
 
 donor_relationship_mention:
     donor_relationship = DonorRelationship (Choice Value)
-        # Was the first renal transplant donor biologically related to the recipient?
+        # Was the first renal transplant donor biologically related to the recipient? RELATED: Donor was biologically related to the renal transplant recipient; UNRELATED: Donor was biologically unrelated to the renal transplant recipient; NOT_MENTIONED: Donor relationship status was not mentioned
         # Possible Values:
-        #   - Donor was biologically related to the renal transplant recipient
-        #   - Donor was biologically unrelated to the renal transplant recipient
-        #   - Donor relationship status was not mentioned
+        #   - RELATED
+        #   - UNRELATED
+        #   - NOT_MENTIONED
 
 
 donor_hla_match_quality_mention:
     donor_hla_match_quality = DonorHlaMatchQuality (Choice Value)
-        # What was the HLA match quality for the first renal transplant?
+        # What was the HLA match quality for the first renal transplant? WELL: Well matched (0-1 mismatches) OR recipient explicitly documented as not sensitized; MODERATE: Moderately matched (2-4 mismatches) OR recipient explicitly documented as sensitized; POOR: Poorly matched (5-6 mismatches) OR recipient explicitly documented as highly sensitized; NOT_MENTIONED: HLA match quality not mentioned
         # Possible Values:
-        #   - Well matched (0-1 mismatches) OR recipient explicitly documented as not sensitized
-        #   - Moderately matched (2-4 mismatches) OR recipient explicitly documented as sensitized
-        #   - Poorly matched (5-6 mismatches) OR recipient explicitly documented as highly sensitized
-        #   - HLA match quality not mentioned
+        #   - WELL
+        #   - MODERATE
+        #   - POOR
+        #   - NOT_MENTIONED
 
 
 donor_hla_mismatch_count_mention:
     donor_hla_mismatch_count = DonorHlaMismatchCount (Choice Value)
-        # What was the donor-recipient HLA mismatch count for the first renal transplant?
+        # What was the donor-recipient HLA mismatch count for the first renal transplant? ZERO: 0 mismatches; ONE: 1 mismatch; TWO: 2 mismatches; THREE: 3 mismatches; FOUR: 4 mismatches; FIVE: 5 mismatches; SIX: 6 mismatches; NOT_MENTIONED: HLA mismatch count not mentioned
         # Possible Values:
-        #   - 0
-        #   - 1
-        #   - 2
-        #   - 3
-        #   - 4
-        #   - 5
-        #   - 6
-        #   - HLA mismatch count not mentioned
+        #   - ZERO
+        #   - ONE
+        #   - TWO
+        #   - THREE
+        #   - FOUR
+        #   - FIVE
+        #   - SIX
+        #   - NOT_MENTIONED
 
 
 donor_serostatus_mention:

--- a/cumulus_library_kidney_transplant/llm/summaries/longitudinal_summary.txt
+++ b/cumulus_library_kidney_transplant/llm/summaries/longitudinal_summary.txt
@@ -1,124 +1,124 @@
 model = "KidneyTransplantLongitudinalAnnotation"
 rx_therapeutic_status_mention:
     rx_therapeutic_status = RxTherapeuticStatus (Choice Value)
-        # In the present encounter, what is the documented immunosuppression level?
+        # In the present encounter, what is the documented immunosuppression level? THERAPEUTIC: Immunosuppression levels are documented as therapeutic, adequate, or within target range; SUB_THERAPEUTIC: Immunosuppression levels are documented as subtherapeutic, insufficient, or below target range; SUPRA_THERAPEUTIC: Immunosuppression levels are documented as supratherapeutic, above therapeutic level, or above target range; NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - Immunosuppression levels are documented as therapeutic, adequate, or within target range.
-        #   - Immunosuppression levels are documented as subtherapeutic, insufficient, or below target range.
-        #   - Immunosuppression levels are documented as supratherapeutic, above therapeutic level, or above target range.
-        #   - None of the above
+        #   - THERAPEUTIC
+        #   - SUB_THERAPEUTIC
+        #   - SUPRA_THERAPEUTIC
+        #   - NONE_OF_THE_ABOVE
 
 
 rx_compliance_mention:
     rx_compliance = RxCompliance (Choice Value)
-        # In the present encounter, is the patient documented as compliant with immunosuppressive medications?
+        # In the present encounter, is the patient documented as compliant with immunosuppressive medications? COMPLIANT: Patient is documented as compliant with immunosuppressive medications; PARTIALLY_COMPLIANT: Patient is documented as only partially compliant with immunosuppressive medications; NON_COMPLIANT: Patient is documented as noncompliant with immunosuppressive medications; NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - Patient is documented as compliant with immunosuppressive medications.
-        #   - Patient is documented as only partially compliant with immunosuppressive medications.
-        #   - Patient is documented as noncompliant with immunosuppressive medications.
-        #   - None of the above
+        #   - COMPLIANT
+        #   - PARTIALLY_COMPLIANT
+        #   - NON_COMPLIANT
+        #   - NONE_OF_THE_ABOVE
 
 
 dsa_mention:
     dsa_history = True or False
         # Does the patient have a past medical history of donor specific antibodies (DSA)?
     dsa = DSAPresent (Choice Value)
-        # What evidence documents donor specific antibodies (DSA) as current, active, or being evaluated/treated now?
+        # What evidence documents donor specific antibodies (DSA) as current, active, or being evaluated/treated now? CONFIRMED: DSA diagnostic test positive, DSA diagnosis 'confirmed' or 'positive', or increase in immunosuppression due to DSA; SUSPECTED: DSA suspected, DSA likely, DSA cannot be ruled out, DSA test result pending, or treatment with IVIG/plasmapheresis; NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - DSA diagnostic test positive, DSA diagnosis 'confirmed' or 'positive', or increase in immunosuppression due to DSA
-        #   - DSA suspected, DSA likely, DSA cannot be ruled out, DSA test result pending, or treatment with IVIG/plasmapheresis
-        #   - None of the above
+        #   - CONFIRMED
+        #   - SUSPECTED
+        #   - NONE_OF_THE_ABOVE
 
 
 infection_mention:
     infection_history = True or False
         # Does the patient have a past medical history of an infection?
     infection = InfectionPresent (Choice Value)
-        # What evidence documents infection as current, active, or being evaluated/treated now?
+        # What evidence documents infection as current, active, or being evaluated/treated now? CONFIRMED: Infection confirmed by laboratory test or imaging, infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to infection; SUSPECTED: Infection is suspected, likely, cannot be ruled out, infection is a differential diagnosis or infectious test result is pending; NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - Infection confirmed by laboratory test or imaging, infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to infection
-        #   - Infection is suspected, likely, cannot be ruled out, infection is a differential diagnosis or infectious test result is pending
-        #   - None of the above
+        #   - CONFIRMED
+        #   - SUSPECTED
+        #   - NONE_OF_THE_ABOVE
 
 
 viral_infection_mention:
     viral_infection_history = True or False
         # Does the patient have a past medical history of a viral infection?
     viral_infection = ViralInfectionPresent (Choice Value)
-        # What evidence documents viral infection as current, active, or being evaluated/treated now?
+        # What evidence documents viral infection as current, active, or being evaluated/treated now? CONFIRMED: Viral infection confirmed by laboratory test or imaging, viral infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to viral infection; SUSPECTED: Viral infection is suspected, likely, cannot be ruled out, viral infection is a differential diagnosis or viral test result is pending; NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - Viral infection confirmed by laboratory test or imaging, viral infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to viral infection
-        #   - Viral infection is suspected, likely, cannot be ruled out, viral infection is a differential diagnosis or viral test result is pending
-        #   - None of the above
+        #   - CONFIRMED
+        #   - SUSPECTED
+        #   - NONE_OF_THE_ABOVE
 
 
 bacterial_infection_mention:
     bacterial_infection_history = True or False
         # Does the patient have a past medical history of a bacterial infection?
     bacterial_infection = BacterialInfectionPresent (Choice Value)
-        # What evidence documents bacterial infection as current, active, or being evaluated/treated now?
+        # What evidence documents bacterial infection as current, active, or being evaluated/treated now? CONFIRMED: Bacterial infection confirmed by laboratory test or imaging, bacterial infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to bacterial infection; SUSPECTED: Bacterial infection is suspected, likely, cannot be ruled out, bacterial infection is a differential diagnosis or bacterial test result is pending; NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - Bacterial infection confirmed by laboratory test or imaging, bacterial infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to bacterial infection
-        #   - Bacterial infection is suspected, likely, cannot be ruled out, bacterial infection is a differential diagnosis or bacterial test result is pending
-        #   - None of the above
+        #   - CONFIRMED
+        #   - SUSPECTED
+        #   - NONE_OF_THE_ABOVE
 
 
 fungal_infection_mention:
     fungal_infection_history = True or False
         # Does the patient have a past medical history of a fungal infection?
     fungal_infection = FungalInfectionPresent (Choice Value)
-        # What evidence documents fungal infection as current, active, or being evaluated/treated now?
+        # What evidence documents fungal infection as current, active, or being evaluated/treated now? CONFIRMED: Fungal infection confirmed by laboratory test or imaging, fungal infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to fungal infection; SUSPECTED: Fungal infection is suspected, likely, cannot be ruled out, fungal infection is a differential diagnosis or fungal test result is pending; NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - Fungal infection confirmed by laboratory test or imaging, fungal infection diagnosis was 'confirmed' or 'positive', or reduced immunosuppression due to fungal infection
-        #   - Fungal infection is suspected, likely, cannot be ruled out, fungal infection is a differential diagnosis or fungal test result is pending
-        #   - None of the above
+        #   - CONFIRMED
+        #   - SUSPECTED
+        #   - NONE_OF_THE_ABOVE
 
 
 graft_rejection_mention:
     graft_rejection_history = True or False
         # Does the patient have a past medical history of kidney graft rejection?
     graft_rejection = GraftRejectionPresent (Choice Value)
-        # What evidence documents kidney graft rejection as current, active, or being evaluated/treated now?
+        # What evidence documents kidney graft rejection as current, active, or being evaluated/treated now? BIOPSY_PROVEN: Biopsy proven kidney graft rejection or pathology proven kidney graft rejection; CONFIRMED: Kidney graft rejection was 'diagnosed', 'confirmed' or 'positive'; SUSPECTED: Kidney graft rejection presumed, suspected, likely, cannot be ruled out, biopsy result pending, or treatment with IVIG/plasmapheresis; NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - Biopsy proven kidney graft rejection or pathology proven kidney graft rejection
-        #   - Kidney graft rejection was 'diagnosed', 'confirmed' or 'positive'
-        #   - Kidney graft rejection presumed, suspected, likely, cannot be ruled out, biopsy result pending, or treatment with IVIG/plasmapheresis
-        #   - None of the above
+        #   - BIOPSY_PROVEN
+        #   - CONFIRMED
+        #   - SUSPECTED
+        #   - NONE_OF_THE_ABOVE
 
 
 graft_failure_mention:
     graft_failure_history = True or False
         # Does the patient have a past medical history of kidney graft failure?
     graft_failure = GraftFailurePresent (Choice Value)
-        # What evidence documents kidney graft failure as current, active, or being evaluated/treated now?
+        # What evidence documents kidney graft failure as current, active, or being evaluated/treated now? CONFIRMED: Kidney graft has failed or kidney graft loss; SUSPECTED: Kidney graft failure presumed, suspected, likely, or cannot be ruled out; NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - Kidney graft has failed or kidney graft loss
-        #   - Kidney graft failure presumed, suspected, likely, or cannot be ruled out
-        #   - None of the above
+        #   - CONFIRMED
+        #   - SUSPECTED
+        #   - NONE_OF_THE_ABOVE
 
 
 ptld_mention:
     ptld_history = True or False
         # Does the patient have a past medical history of post transplant lymphoproliferative disorder (PTLD)?
     ptld = PTLDPresent (Choice Value)
-        # What evidence documents post transplant lymphoproliferative disorder (PTLD) as current, active, or being evaluated/treated now?
+        # What evidence documents post transplant lymphoproliferative disorder (PTLD) as current, active, or being evaluated/treated now? BIOPSY_PROVEN: Biopsy proven or pathology proven PTLD; CONFIRMED: PTLD was 'diagnosed', 'confirmed' or 'positive' or viral positive lymphoma; SUSPECTED: PTLD presumed, suspected, likely, cannot be ruled out, PTLD biopsy result pending, or treatment with chemotherapy/radiation; NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - Biopsy proven or pathology proven PTLD
-        #   - PTLD was 'diagnosed', 'confirmed' or 'positive' or viral positive lymphoma
-        #   - PTLD presumed, suspected, likely, cannot be ruled out, PTLD biopsy result pending, or treatment with chemotherapy/radiation
-        #   - None of the above
+        #   - BIOPSY_PROVEN
+        #   - CONFIRMED
+        #   - SUSPECTED
+        #   - NONE_OF_THE_ABOVE
 
 
 cancer_mention:
     cancer_history = True or False
         # Does the patient have a past medical history of cancer?
     cancer = CancerPresent (Choice Value)
-        # What evidence documents cancer as current, active, or being evaluated/treated now?
+        # What evidence documents cancer as current, active, or being evaluated/treated now? BIOPSY_PROVEN: Biopsy proven or pathology proven cancer; CONFIRMED: Cancer was 'diagnosed', 'confirmed' or 'positive'; SUSPECTED: Cancer is presumed, suspected, likely, cannot be ruled out, biopsy of any lesion, or treatment with chemotherapy/radiation; NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - Biopsy proven or pathology proven cancer
-        #   - Cancer was 'diagnosed', 'confirmed' or 'positive'
-        #   - Cancer is presumed, suspected, likely, cannot be ruled out, biopsy of any lesion, or treatment with chemotherapy/radiation
-        #   - None of the above
+        #   - BIOPSY_PROVEN
+        #   - CONFIRMED
+        #   - SUSPECTED
+        #   - NONE_OF_THE_ABOVE
 
 
 deceased_mention:

--- a/cumulus_library_kidney_transplant/llm/summaries/treatment_summary.txt
+++ b/cumulus_library_kidney_transplant/llm/summaries/treatment_summary.txt
@@ -1,44 +1,44 @@
 model = "ImmunosuppressiveMedicationsAnnotation"
 immunosuppressive_medication_mentions: A (possibly empty) list of ImmunosuppressiveMedicationMention instances, which contain:
     status = RxStatus (Choice Value)
-        # What is the status of this medication?
+        # What is the status of this medication? ACTIVE: Medication order is active (currently prescribed and intended for ongoing use); INTENDED: Medication is planned/ordered/prescribed but therapy has not yet started; COMPLETED: Medication course is finished (all doses given or intended duration completed); STOPPED: Medication was stopped or permanently discontinued before completion; CANCELED: Medication order was canceled/withdrawn before any doses were administered; ON_HOLD: Medication is temporarily paused (on-hold, suspended, or interrupted); NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - Medication order is active (currently prescribed and intended for ongoing use).
-        #   - Medication is planned/ordered/prescribed but therapy has not yet started.
-        #   - Medication course is finished (all doses given or intended duration completed).
-        #   - Medication was stopped or permanently discontinued before completion.
-        #   - Medication order was canceled/withdrawn before any doses were administered.
-        #   - Medication is temporarily paused (on-hold, suspended, or interrupted).
-        #   - None of the above
+        #   - ACTIVE
+        #   - INTENDED
+        #   - COMPLETED
+        #   - STOPPED
+        #   - CANCELED
+        #   - ON_HOLD
+        #   - NONE_OF_THE_ABOVE
     category = RxCategory (Choice Value)
-        # In which healthcare setting is this medication prescribed/administered?
+        # In which healthcare setting is this medication prescribed/administered? INPATIENT: Medication ordered/administered during an inpatient/acute care setting; OUTPATIENT: Medication ordered/administered during an outpatient setting; COMMUNITY: Medication ordered/consumed by the patient in their home (including long term care, nursing homes, etc); NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - Medication ordered/administered during an inpatient/acute care setting
-        #   - Medication ordered/administered during an outpatient setting
-        #   - Medication ordered/consumed by the patient in their home (including long term care, nursing homes, etc)
-        #   - None of the above
+        #   - INPATIENT
+        #   - OUTPATIENT
+        #   - COMMUNITY
+        #   - NONE_OF_THE_ABOVE
     route = RxRoute (Choice Value)
-        # What is the the route of administration for this medication?
+        # What is the route of administration for this medication? PO: Oral (includes swallowed and sublingual routes); NG: Nasogastric/Feeding tube (NG/PEG); INJECTION: Injection (IV, SC, or IM); INHALATION: Inhalation (respiratory route); TOPICAL: Topical (skin or mucosal surface); NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - Oral (includes swallowed and sublingual routes)
-        #   - Nasogastric/Feeding tube (NG/PEG)
-        #   - Injection (IV, SC, or IM)
-        #   - Inhalation (respiratory route)
-        #   - Topical (skin or mucosal surface)
-        #   - None of the above
+        #   - PO
+        #   - NG
+        #   - INJECTION
+        #   - INHALATION
+        #   - TOPICAL
+        #   - NONE_OF_THE_ABOVE
     phase = TreatmentPhase (Choice Value)
-        # What is the treatment phase for this medication?
+        # What is the treatment phase for this medication? INDUCTION: Induction therapy; MAINTENANCE: Maintenance therapy; RESCUE: Rescue therapy; NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - Induction therapy
-        #   - Maintenance therapy
-        #   - Rescue therapy
-        #   - None of the above
+        #   - INDUCTION
+        #   - MAINTENANCE
+        #   - RESCUE
+        #   - NONE_OF_THE_ABOVE
     expected_supply_days = Optional mention of [Integer number]
         # Number of days the medication supply is supposed to last (stale dating the prescription)
     number_of_repeats_allowed = Optional mention of [Integer number]
         # number of times (aka refills or repeats) that the patient can receive the prescribed medication
     frequency = RxFrequency (Choice Value)
-        # What is the frequency of this medication?
+        # What is the frequency of this medication? QD: once daily; BID: twice daily; TID: three times daily; QID: four times daily; QOD: every other day; Q6H: every 6 hours; Q8H: every 8 hours; Q12H: every 12 hours; WEEKLY: once weekly; Q2W: once every 2 weeks; Q4W: once every 4 weeks; MONTHLY: once monthly; OTHER: non-standard frequency (use timing_text); NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
         #   - QD
         #   - BID
@@ -53,78 +53,78 @@ immunosuppressive_medication_mentions: A (possibly empty) list of Immunosuppress
         #   - Q4W
         #   - MONTHLY
         #   - OTHER
-        #   - None of the above
+        #   - NONE_OF_THE_ABOVE
     start_date = Optional mention of [Plaintext string]
         # Start date of the prescribed or administered medication
     end_date = Optional mention of [Plaintext string]
         # End date of the prescribed or administered medication
     quantity_unit = RxQuantityUnit (Choice Value)
-        # Medication prescribed unit
+        # Medication prescribed unit. Mass: MG=mg, G=g, UG=ug (microgram), KG=kg; Volume: ML=mL, L=L; International Units: U=U, IU=[iU]; Countable: TABLET, CAPSULE, PUFF, PATCH, SUPPOSITORY; Ratios: MG_PER_ML, MG_PER_KG, U_PER_KG, UG_PER_KG_PER_MIN; Time: H=hours, MIN=minutes, D=days; NONE_OF_THE_ABOVE: None of the above
         # Possible Values:
-        #   - mg
-        #   - g
-        #   - ug
-        #   - kg
-        #   - mL
+        #   - MG
+        #   - G
+        #   - UG
+        #   - KG
+        #   - ML
         #   - L
         #   - U
-        #   - [iU]
-        #   - {tablet}
-        #   - {capsule}
-        #   - {puff}
-        #   - {patch}
-        #   - {suppository}
-        #   - mg/mL
-        #   - mg/kg
-        #   - U/kg
-        #   - ug/kg/min
-        #   - h
-        #   - min
-        #   - d
-        #   - None of the above
+        #   - IU
+        #   - TABLET
+        #   - CAPSULE
+        #   - PUFF
+        #   - PATCH
+        #   - SUPPOSITORY
+        #   - MG_PER_ML
+        #   - MG_PER_KG
+        #   - U_PER_KG
+        #   - UG_PER_KG_PER_MIN
+        #   - H
+        #   - MIN
+        #   - D
+        #   - NONE_OF_THE_ABOVE
     quantity_value = Optional mention of [Plaintext string]
         # Numeric amount of medication prescribed or administered (FHIR Quantity.value)
     drug_class = RxClassImmunosuppression (Choice Value)
-        # Extract the Immunosuppressive drug class or therapy modality documented for this medication, if present
+        # Extract the Immunosuppressive drug class or therapy modality documented for this medication, if present. ANTIMET: Anti-Metabolite (e.g., azathioprine, mycophenolate); CNI: Calcineurin Inhibitor (e.g., tacrolimus, cyclosporine); STEROID: Corticosteroid (e.g., prednisone, methylprednisolone); MTOR: mTOR Inhibitor (e.g., sirolimus, everolimus); COSTIM: Costimulation Blocker/blockade (e.g., belatacept); IVIG: Immunoglobulin (e.g., IVIG, Cytogam); POLYCLONAL: Polyclonal antibody (e.g., ATG, ALG); MONOCLONAL: Monoclonal antibody (e.g., basiliximab, rituximab); OTHER: Other immunosuppressive drug; NONE: None of the above
         # Possible Values:
-        #   - Anti-Metabolite (ANTIMET)
-        #   - Calcineurin Inhibitor (CNI)
-        #   - Corticosteroid (CS)
-        #   - mTOR Inhibitor (MTOR)
-        #   - Costimulation Blocker/blockade (COSTIM)
-        #   - Immunoglobulin (IVIG)
-        #   - Polyclonal antibody (e.g., ATG, ALG)
-        #   - Monoclonal antibody (mAb, e.g., basiliximab, rituximab)
-        #   - Other immunosuppressive drug
-        #   - None of the above
+        #   - ANTIMET
+        #   - CNI
+        #   - STEROID
+        #   - MTOR
+        #   - COSTIM
+        #   - IVIG
+        #   - POLYCLONAL
+        #   - MONOCLONAL
+        #   - OTHER
+        #   - NONE
     ingredient = RxIngredientImmunosuppression (Choice Value)
-        # Extract the specific immunosuppressive drug ingredient documented for this medication, if present
+        # Extract the specific immunosuppressive drug ingredient documented for this medication, if present. ANTIMET group: AZA=Azathioprine, MMF=Mycophenolate Mofetil, ANTIMET_OTHER=other anti-metabolite; CNI group: CYA=Cyclosporine, TAC=Tacrolimus, CNI_OTHER=other calcineurin inhibitor; STEROID group: MEDROL=Methylprednisolone, PDL=Prednisolone, PRED=Prednisone, STEROID_OTHER=other corticosteroid; COSTIM group: BEL=Belatacept, ABA=Abatacept, COSTIM_OTHER=other costimulation blocker; IVIG group: IVIG=Intravenous Immunoglobulin, CYTOGAM=Cytogam (CMV-specific hyperimmune globulin), IVIG_OTHER=other immunoglobulin; MTOR group: EVE=Everolimus, SRL=Sirolimus, MTOR_OTHER=other mTOR inhibitor; MONOCLONAL group: ALEM=Alemtuzumab, BASI=Basiliximab, DAC=Daclizumab, RTX=Rituximab, MONOCLONAL_OTHER=other monoclonal antibody; POLYCLONAL group: ATG=Antithymocyte Globulin, POLYCLONAL_OTHER=other polyclonal antibody; NONE: None of the above
         # Possible Values:
-        #   - Azathioprine
-        #   - Mycophenolate Mofetil
-        #   - Other anti-metabolite ingredient
-        #   - Cyclosporine
-        #   - Tacrolimus
-        #   - Other calcineurin inhibitor ingredient
-        #   - Methylprednisolone
-        #   - Prednisolone
-        #   - Prednisone
-        #   - Other corticosteroid ingredient
-        #   - Belatacept
-        #   - Abatacept
-        #   - Other Costimulation blocker ingredient
-        #   - Intravenous Immunoglobulin (IVIG)
-        #   - Cytogam (CMV-specific hyperimmune globulin)
-        #   - Other immunoglobulin therapy
-        #   - Everolimus
-        #   - Sirolimus
-        #   - Other mTOR inhibitor ingredient
-        #   - Alemtuzumab
-        #   - Basiliximab
-        #   - Daclizumab
-        #   - Rituximab
-        #   - Other Monoclonal antibody drug
-        #   - Antithymocyte Globulin (ATG)
-        #   - Other polyclonal antibodies ingredient
-        #   - None of the above
+        #   - AZA
+        #   - MMF
+        #   - ANTIMET_OTHER
+        #   - CYA
+        #   - TAC
+        #   - CNI_OTHER
+        #   - MEDROL
+        #   - PDL
+        #   - PRED
+        #   - STEROID_OTHER
+        #   - BEL
+        #   - ABA
+        #   - COSTIM_OTHER
+        #   - IVIG
+        #   - CYTOGAM
+        #   - IVIG_OTHER
+        #   - EVE
+        #   - SRL
+        #   - MTOR_OTHER
+        #   - ALEM
+        #   - BASI
+        #   - DAC
+        #   - RTX
+        #   - MONOCLONAL_OTHER
+        #   - ATG
+        #   - POLYCLONAL_OTHER
+        #   - NONE
 

--- a/cumulus_library_kidney_transplant/llm/template/irae__llm_donor_highlights.sql.jinja
+++ b/cumulus_library_kidney_transplant/llm/template/irae__llm_donor_highlights.sql.jinja
@@ -66,23 +66,23 @@ CREATE TABLE irae__llm_donor_highlights AS
         {{ table_name }} AS src, 
         UNNEST(src.result.{{mention_key}}.spans) AS t3(span)
     -- Custom filtering per mention_key
-    WHERE 
-        src.task_version = CAST('7' AS INT)
+    WHERE
+        src.task_version = 8
     {%- if mention_key == 'donor_transplant_date_mention' %}
         AND src.result.{{mention_key}} IS NOT NULL
         AND src.result.{{mention_key}}.donor_transplant_date IS NOT NULL
     {%- elif mention_key == 'donor_type_mention' %}
         AND src.result.{{mention_key}} IS NOT NULL
-        AND src.result.{{mention_key}}.donor_type != 'Donor was not mentioned as living or deceased'
+        AND src.result.{{mention_key}}.donor_type != 'NOT_MENTIONED'
     {%- elif mention_key == 'donor_relationship_mention' %}
         AND src.result.{{mention_key}} IS NOT NULL
-        AND src.result.{{mention_key}}.donor_relationship != 'Donor relationship status was not mentioned' 
+        AND src.result.{{mention_key}}.donor_relationship != 'NOT_MENTIONED'
     {%- elif mention_key == 'donor_hla_match_quality_mention' %}
         AND src.result.{{mention_key}} IS NOT NULL
-        AND src.result.{{mention_key}}.donor_hla_match_quality != 'HLA match quality not mentioned' 
+        AND src.result.{{mention_key}}.donor_hla_match_quality != 'NOT_MENTIONED'
     {%- elif mention_key == 'donor_hla_mismatch_count_mention' %}
         AND src.result.{{mention_key}} IS NOT NULL
-        AND src.result.{{mention_key}}.donor_hla_mismatch_count != 'HLA mismatch count not mentioned' 
+        AND src.result.{{mention_key}}.donor_hla_mismatch_count != 'NOT_MENTIONED'
     {%- elif mention_key == 'donor_serostatus_mention' %}
         AND src.result.{{mention_key}} IS NOT NULL
         AND src.result.{{mention_key}}.serostatus != 'NOT_MENTIONED' 

--- a/cumulus_library_kidney_transplant/llm/template/irae__llm_donor_wide.sql.jinja
+++ b/cumulus_library_kidney_transplant/llm/template/irae__llm_donor_wide.sql.jinja
@@ -22,6 +22,6 @@ SELECT DISTINCT
 FROM
     {{ table_name }} AS nlp
 WHERE
-    task_version = 7
+    task_version = 8
 {{ syntax.union_all_delineate(loop) }}
 {%- endfor %}

--- a/cumulus_library_kidney_transplant/llm/template/irae__llm_immunosuppressive_medications_highlights.sql.jinja
+++ b/cumulus_library_kidney_transplant/llm/template/irae__llm_immunosuppressive_medications_highlights.sql.jinja
@@ -23,9 +23,9 @@ FROM
             CAST(ARRAY[ARRAY[]] AS ARRAY(ARRAY(INTEGER)))
         )
     ) AS t2(span)
-WHERE 
-    src.task_version = CAST('6' AS INT)
-    AND medication.status <> 'None of the above'
+WHERE
+    src.task_version = 7
+    AND medication.status <> 'NONE_OF_THE_ABOVE'
 -- Second pass to get medication ingredient information --
 UNION ALL
 SELECT
@@ -39,17 +39,17 @@ SELECT
     CONCAT(CAST(span[1] AS VARCHAR), ':', CAST(span[2] AS VARCHAR)) AS span,
     'Medication' AS sublabel_name,
     medication.ingredient AS sublabel_value
-FROM 
+FROM
     {{ table_name }} AS src,
     UNNEST(src.result.immunosuppressive_medication_mentions) AS t1(medication),
     UNNEST(
         COALESCE(
-            medication.spans, 
+            medication.spans,
             CAST(ARRAY[ARRAY[]] AS ARRAY(ARRAY(INTEGER)))
         )
     ) AS t2(span)
-WHERE 
-    src.task_version = CAST('6' AS INT)
-    AND medication.ingredient <> 'None of the above'
+WHERE
+    src.task_version = 7
+    AND medication.ingredient <> 'NONE_OF_THE_ABOVE'
 {{ syntax.union_all_delineate(loop) }}
 {%- endfor %}

--- a/cumulus_library_kidney_transplant/llm/template/irae__llm_immunosuppressive_medications_wide.sql.jinja
+++ b/cumulus_library_kidney_transplant/llm/template/irae__llm_immunosuppressive_medications_wide.sql.jinja
@@ -29,7 +29,7 @@ FROM
     {{ table_name }} AS nlp,
     UNNEST(nlp.result.immunosuppressive_medication_mentions) AS t(medication)
 WHERE
-    task_version = 6
-    AND medication.drug_class <> 'None of the above'
+    task_version = 7
+    AND medication.drug_class <> 'NONE_OF_THE_ABOVE'
 {{ syntax.union_all_delineate(loop) }}
 {%- endfor %}

--- a/cumulus_library_kidney_transplant/llm/template/irae__llm_longitudinal_highlights.sql.jinja
+++ b/cumulus_library_kidney_transplant/llm/template/irae__llm_longitudinal_highlights.sql.jinja
@@ -72,46 +72,46 @@ CREATE TABLE irae__llm_longitudinal_highlights AS
     -- Custom filtering per mention_key 
     {%- if mention_key == 'rx_therapeutic_status_mention' %}
     WHERE
-        src.result.{{mention_key}}.rx_therapeutic_status != 'None of the above' 
+        src.result.{{mention_key}}.rx_therapeutic_status != 'NONE_OF_THE_ABOVE'
     {%- elif mention_key == 'rx_compliance_mention' %}
     WHERE
-        src.result.{{mention_key}}.rx_compliance != 'None of the above' 
+        src.result.{{mention_key}}.rx_compliance != 'NONE_OF_THE_ABOVE'
     {%- elif mention_key == 'dsa_mention' %}
-    WHERE 
+    WHERE
         src.result.{{mention_key}}.{{ mention_key.replace('mention', 'history') }}
-        AND src.result.{{mention_key}}.dsa != 'None of the above' 
+        AND src.result.{{mention_key}}.dsa != 'NONE_OF_THE_ABOVE'
     {%- elif mention_key == 'infection_mention' %}
-    WHERE 
+    WHERE
         src.result.{{mention_key}}.{{ mention_key.replace('mention', 'history') }}
-        AND src.result.{{mention_key}}.infection != 'None of the above' 
+        AND src.result.{{mention_key}}.infection != 'NONE_OF_THE_ABOVE'
     {%- elif mention_key == 'viral_infection_mention' %}
-    WHERE 
+    WHERE
         src.result.{{mention_key}}.{{ mention_key.replace('mention', 'history') }}
-        AND src.result.{{mention_key}}.viral_infection != 'None of the above' 
+        AND src.result.{{mention_key}}.viral_infection != 'NONE_OF_THE_ABOVE'
     {%- elif mention_key == 'bacterial_infection_mention' %}
-    WHERE 
+    WHERE
         src.result.{{mention_key}}.{{ mention_key.replace('mention', 'history') }}
-        AND src.result.{{mention_key}}.bacterial_infection != 'None of the above' 
+        AND src.result.{{mention_key}}.bacterial_infection != 'NONE_OF_THE_ABOVE'
     {%- elif mention_key == 'fungal_infection_mention' %}
-    WHERE 
+    WHERE
         src.result.{{mention_key}}.{{ mention_key.replace('mention', 'history') }}
-        AND src.result.{{mention_key}}.fungal_infection != 'None of the above' 
+        AND src.result.{{mention_key}}.fungal_infection != 'NONE_OF_THE_ABOVE'
     {%- elif mention_key == 'graft_rejection_mention' %}
-    WHERE 
+    WHERE
         src.result.{{mention_key}}.{{ mention_key.replace('mention', 'history') }}
-        AND src.result.{{mention_key}}.graft_rejection != 'None of the above' 
+        AND src.result.{{mention_key}}.graft_rejection != 'NONE_OF_THE_ABOVE'
     {%- elif mention_key == 'graft_failure_mention' %}
-    WHERE 
+    WHERE
         src.result.{{mention_key}}.{{ mention_key.replace('mention', 'history') }}
-        AND src.result.{{mention_key}}.graft_failure != 'None of the above' 
+        AND src.result.{{mention_key}}.graft_failure != 'NONE_OF_THE_ABOVE'
     {%- elif mention_key == 'ptld_mention' %}
-    WHERE 
+    WHERE
         src.result.{{mention_key}}.{{ mention_key.replace('mention', 'history') }}
-        AND src.result.{{mention_key}}.ptld != 'None of the above' 
+        AND src.result.{{mention_key}}.ptld != 'NONE_OF_THE_ABOVE'
     {%- elif mention_key == 'cancer_mention' %}
-    WHERE 
+    WHERE
         src.result.{{mention_key}}.{{ mention_key.replace('mention', 'history') }}
-        AND src.result.{{mention_key}}.cancer != 'None of the above' 
+        AND src.result.{{mention_key}}.cancer != 'NONE_OF_THE_ABOVE'
     {%- elif mention_key == 'deceased_mention' %}
     WHERE 
         src.result.{{mention_key}}.deceased IS NOT NULL

--- a/cumulus_library_kidney_transplant/llm/template/irae__llm_longitudinal_wide.sql.jinja
+++ b/cumulus_library_kidney_transplant/llm/template/irae__llm_longitudinal_wide.sql.jinja
@@ -43,6 +43,6 @@ SELECT DISTINCT
 FROM
     {{ table_name }} AS nlp
 WHERE
-    task_version = 6
+    task_version = 7
 {{ syntax.union_all_delineate(loop) }}
 {%- endfor %}

--- a/cumulus_library_kidney_transplant/nlp_clinical_tasks.toml
+++ b/cumulus_library_kidney_transplant/nlp_clinical_tasks.toml
@@ -34,20 +34,18 @@ Here is the clinical document for you to analyze:
 %CLINICAL-NOTE%
 """
 
-# 
-# 
-# 
 
 [tables.donor]
 response_schema = "llm/schemas/irae_donor.json"
 # Version History:
+# ** 8 (2026-06): Enum alignment (key=value CAPS_UNDER_BAR) **
 # ** 7 (2025-12): Serostatus mentions added
 # ** 6 (2025-11): Pydantic updates (donors refer to 1st transplant;
 #                 POD inference guidance; new multiple transplant task) **
 # ** 5 (2025-10): Update pydantic model (biological relation;
 #                 Defaults for SpanAugmentedMention properties) **
 # ** 4 (2025-10): Initial version**
-version = 7
+version = 8
 # When we add document-level tasks, we can use `select_by_table` to specify 
 # that this table should only be built for documents that meet certain criteria. 
 # select_by_table = "irae__llm_document_task_diagnosis"
@@ -55,18 +53,20 @@ version = 7
 
 
 [tables.immunosuppressive_medications]
-response_schema = "llm/schemas/irae_meds.json"
+response_schema = "llm/schemas/irae_medications.json"
 # Version History:
+# ** 7 (2026-06): Enum alignment (key=value CAPS_UNDER_BAR) **
 # ** 6 (2025-12): Initial version
-version = 6
+version = 7
 # When we add document-level tasks, we can use `select_by_table` to specify 
 # that this table should only be built for documents that meet certain criteria. 
 # select_by_table = "irae__llm_document_task_diagnosis"
 
 
 [tables.longitudinal]
-response_schema = "llm/schemas/irae_longitudinal.json"
+response_schema = "llm/schemas/irae_outcomes.json"
 # Version History:
+# ** 7 (2026-06): Enum alignment (key=value CAPS_UNDER_BAR) **
 # ** 6 (2025-11): Pydantic updates (donors refer to 1st transplant;
 #                 POD inference guidance; new multiple transplant task) **
 # ** 5 (2025-10): Update pydantic model (biological relation;
@@ -76,7 +76,7 @@ response_schema = "llm/schemas/irae_longitudinal.json"
 # ** 2 (2025-09): Updated prompt and schema **
 # ** 1 (2025-08): Updated prompt **
 # ** 0 (2025-08): Initial version **
-version = 6
+version = 7
 # When we add document-level tasks, we can use `select_by_table` to specify 
 # that this table should only be built for documents that meet certain criteria. 
 # select_by_table = "irae__llm_document_task_diagnosis"
@@ -84,7 +84,7 @@ version = 6
 
 
 [tables.multiple_transplant_history]
-response_schema = "llm/schemas/irae_history.json"
+response_schema = "llm/schemas/irae_multiple_transplant_history.json"
 # Version History:
 # ** 6 (2025-12): Initial version
 version = 6


### PR DESCRIPTION
Major changes: 
- Updates to enum s.t. names now aligned with values; 
- Removed vestigial generation main methods in pydantic classes; 
- Bumps version numbers for impacted pydantic classes
- Regenerates artifacts downstream 
- Adds a PR template file

## Detailed changes: 
 Pydantic models updated (llm/model/):
  - base.py: All enum values changed to self-referential CAPS_UNDER_BAR keys. RxFrequency.NONE converted to NONE_OF_THE_ABOVE; RxStatus, RxCategory, RxRoute, RxQuantityUnit, and TreatmentPhase all updated. Descriptions moved from values into class docstrings in addition to the mention class descriptions.
  - donor.py: DonorType, DonorRelationship, DonorHlaMatchQuality, DonorHlaMismatchCount (numeric strings like "0"  ->  "ZERO") all aligned. Serostatus was already correct, so yay!
  - outcome.py: All 9 outcome enums (RxTherapeuticStatus, RxCompliance, DSAPresent, all infection types, GraftRejectionPresent, GraftFailurePresent, PTLDPresent, CancerPresent) aligned.
  - medication.py: RxClassImmunosuppression and RxIngredientImmunosuppression aligned.

  SQL templates updated (llm/template/):
  - Across the board: removed unnecessary cast from a fixed str to an int, replaced with an int  
  - Donor highlights: version 7 -> 8, old descriptive string comparisons  ->  'NOT_MENTIONED'
  - Longitudinal highlights: 'None of the above'  ->  'NONE_OF_THE_ABOVE' 
  - Donor wide: version 7 -> 8
  - Longitudinal wide: version 6 -> 7 (ayyyy)
  - Medications highlights: version 6 -> 7, 'None of the above'  ->  'NONE_OF_THE_ABOVE'
  - Medications wide: version 6 -> 7, 'None of the above'  ->  'NONE_OF_THE_ABOVE'


  Version bumps (nlp_clinical_tasks.toml):
  - donor: 7  ->  8
  - immunosuppressive_medications: 6  ->  7 (ayyyy)
  - longitudinal: 6  ->  7