### PR TITLE
Reference `nlp-chunksize` arg in readme and manifest 

### DIFF
--- a/RUNNING-AGREEMENT.md
+++ b/RUNNING-AGREEMENT.md
@@ -148,22 +148,30 @@ is helpful for this annotation process.
 ## 5 Run Donor NLP Task
 
 In parallel to human annotation, we want to generate some LLM-based annotations for this task.
-For the 100 notes previously identified, run the peri-operative NLP stage. This stage covers
-the donor task along with immunosuppressive medications and transplant history.
+For the 100 notes previously identified, run the `nlp` stage. Its peri-operative workflow 
+covers the donor task along with immunosuppressive medications and transplant history — that 
+workflow is the one relevant here. Note that the stage also runs the post-transplant outcome 
+workflow in the same invocation; there is no peri-only stage.
 
 
 ```sh
 cumulus-library build \
   --target irae \
-  --stage nlp_clinical_peri_tasks \
+  --stage nlp \
   --database <relevant_cumulus_library_database> \
   --region <relevant_aws_region> \
   --workgroup <relevant_cumulus_library_workgroup> \
   --note-dir <input folder with ndjson files from step 2 above> \
   --etl-phi-dir <your typical ETL PHI folder> \
   --nlp-model gpt-oss-120b_OR_WHATEVER_MODEL_YOU_ARE_USING \
-  --nlp-provider azure
+  --nlp-provider azure \
+  --nlp-chunksize 5000
 ```
+
+`--nlp-chunksize 5000` sets how many notes are processed before results are written out to 
+storage, so the NLP result tables are created and materialized gradually over the course of 
+the run instead of only at the very end. Pass it as a matter of practice on any NLP run.
+
 
 After running the NLP stage, we want to transform these 
 LLM responses into a format that can be 

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -99,23 +99,31 @@ The example commands below use `gpt-oss-120b` on Azure, but other models and pro
 supported via `--nlp-model` and `--nlp-provider`. See 
 [here](https://docs.smarthealthit.org/cumulus/nlp/models.html) for a full list
 
-The NLP tasks are split into two stages based on which note set they operate on. 
-The note cohort each stage selects is controlled by `select_by_table` in each workflow file 
-(`nlp_clinical_peri_tasks.toml` and `nlp_clinical_post_tasks.toml`). The instructions here will 
-use a stage defined to work against a small sample of notes, suffixed with `_10`. To 
-run the study's full NLP, just remove this suffix from the stages mentioned
+As a matter of practice, always pass `--nlp-chunksize 5000`. This tells `cumulus-library` how 
+many notes to process before writing results out to storage, so the NLP result tables are 
+created and materialized gradually over the course of a run rather than all at once at the 
+end. 
+
+A single `nlp.toml` manifest runs both note sets, via two workflow files — 
+`nlp_clinical_peri_tasks.workflow` (peri-operative notes) and 
+`nlp_clinical_post_tasks.workflow` (post-transplant notes). The note cohort each one selects 
+is controlled by its `select_by_table` setting. The instructions here use `nlp_10`,  
+defined to work against a small sample of notes. 
+
+To run the study's full NLP, use the `nlp` stage instead
 
 ```sh
 cumulus-library build \
   --target irae \
-  --stage nlp_tasks_10 \
+  --stage nlp_10 \
   --database <relevant_cumulus_library_database> \
   --region <relevant_aws_region> \
   --workgroup <relevant_cumulus_library_workgroup> \
   --note-dir <input folder with post-transplant ndjson files from step 3 above> \
   --etl-phi-dir <your typical ETL PHI folder> \
   --nlp-model gpt-oss-120b \
-  --nlp-provider azure
+  --nlp-provider azure \
+  --nlp-chunksize 5000
 ```
 
 For notes in our `sample_casedef_peri` table, this will generate NLP annotations for: 
@@ -144,7 +152,7 @@ cumulus-library build \
   --stage nlp_post_processing
 ```
 
-For each of the nlp sub-tasks defined in our previously referenced `nlp_tasks_10` stage, 
+For each of the nlp sub-tasks defined in our previously referenced `nlp_10` stage, 
 we will now have the following: 
 - Flattened, wide-representation tables of all the NLP based observations 
   we have for each task, namespaced as `irae__llm_{task}_wide`

--- a/cumulus_library_kidney_transplant/manifest.toml
+++ b/cumulus_library_kidney_transplant/manifest.toml
@@ -24,14 +24,25 @@ files = ['casedef.toml']
 type = "submanifest"
 files = ['sample.toml']
 
+# ------ <NLP LLM Tasks> ------
+# These stages are for the NLP tasks, which are skipped by default to avoid unnecessary build times
+# Run these stages directly using the --stage flag when running library command. 
+# See docs for more details on how to run specific stages.
 [[stages.nlp]]
 type = "submanifest"
 files = ['nlp_tasks.toml']
+skip_by_default = true
 
 [[stages.nlp_10]]
 type = "submanifest"
 files = ['nlp_tasks_10.toml']
+skip_by_default = true
+# ------ </NLP LLM Tasks> ------
 
+# Translating NLP results into LLM tables, however, is _NOT_ skipped by default. Since these
+# builders can handle cases where the source NLP tables are missing, they can be run without 
+# having to run the NLP tasks first. It's also worth always rebuilding these tables to
+# ensure that any new NLP results are captured in the LLM tables.
 [[stages.nlp_post_processing]]
 type = "submanifest"
 files = ['nlp_post_processing.toml']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">= 3.11"
 dependencies = [
     # we'll try to keep this template up to date, but it's recommended to use the
     # latest minor version of cumulus-library
-    "cumulus-library >= 6.1.0",
+    "cumulus-library >= 6.2.0",
     "pyrfc3339",
     "sqlfluff >= 3, <4",
     "tomli-w",


### PR DESCRIPTION
Also updates the manifest to skip LLM NLP stages by default and updates the version of cumulus-library used. 

### Checklist
- [X] Consider if documentation needs to be updated
- [x] Consider if tests should be added
- [x] If your PR updates Pydantic, make sure you've done the following before finalizing your updates
  - [x] For schemas that have changed, update impacted task versions in **SQL template files**
  - [x] For schemas that have changed, update impacted task versions in **cumulus_library_kidney_transplant/nlp_clinical_peri_tasks.toml** and **cumulus_library_kidney_transplant/nlp_clinical_post_tasks.toml**
  - [x] `python cumulus_library_kidney_transplant/llm/create_model_summary.py`
  - [x] `python cumulus_library_kidney_transplant/llm/create_schema.py`
  - [x] `python cumulus_library_kidney_transplant/llm/create_wide_sql_examples.py`